### PR TITLE
Refactor: change live settings

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+material-tailwind.com

--- a/components/Documentation/Navbar.js
+++ b/components/Documentation/Navbar.js
@@ -13,11 +13,6 @@ export default function IndexNavbar(props) {
         <div className="w-full relative flex justify-between items-center lg:w-auto lg:static lg:block lg:justify-start">
           <Link
             href="/"
-            as={
-              (process.env.NODE_ENV === "production"
-                ? "/material-tailwind"
-                : "") + "/"
-            }
           >
             <a className="text-white text-sm font-medium leading-relaxed inline-block mr-4 whitespace-no-wrap uppercase">
               Material Tailwind
@@ -44,11 +39,6 @@ export default function IndexNavbar(props) {
             >
               <Link
                 href="/documentation/quick-start"
-                as={
-                  (process.env.NODE_ENV === "production"
-                    ? "/material-tailwind"
-                    : "") + "/documentation/quick-start"
-                }
               >
                 <a className="px-3 py-4 lg:py-2 flex items-center text-xs uppercase font-medium">
                   <i className="far fa-file-alt text-lg leading-lg " />
@@ -62,11 +52,6 @@ export default function IndexNavbar(props) {
             >
               <Link
                 href="/components"
-                as={
-                  (process.env.NODE_ENV === "production"
-                    ? "/material-tailwind"
-                    : "") + "/components"
-                }
               >
                 <a className="px-3 py-4 lg:py-2 flex items-center text-xs uppercase font-medium">
                   <i className="fas fa-cubes text-lg leading-lg " />

--- a/components/Documentation/Sidebar.js
+++ b/components/Documentation/Sidebar.js
@@ -120,11 +120,6 @@ class Sidebar extends React.Component {
           <li key={key}>
             <Link
               href={prop.path}
-              as={
-                (process.env.NODE_ENV === "production"
-                  ? "/material-tailwind"
-                  : "") + prop.path
-              }
             >
               <a
                 className={

--- a/next.config.js
+++ b/next.config.js
@@ -10,10 +10,6 @@ module.exports = withFonts(
   withCSS(
     withImages(
       withSass({
-        assetPrefix:
-          process.env.NODE_ENV === "production"
-            ? "/material-tailwind"
-            : "",
         webpack(config, options) {
           config.module.rules.push({
             test: /\.(eot|ttf|woff|woff2)$/,

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "copy:module": "cp -r node_modules/material-ripple-effects lib/ && npm run build:tailwind",
     "prep:package": "cp -r lib-babel.config.json babel.config.json && npm run make:package && npm run assets:package && rm -rf babel.config.json && npm run copy:module",
     "publish:package": "npm run prep:package && cd lib && npm publish --access=public && cd ../",
-    "deploy": "npm run build && npm run export && touch out/.nojekyll && git add out/ && git commit -m \"ready to deploy\" && git push && git subtree push --prefix out origin gh-pages"
+    "deploy": "npm run build && npm run export && cp CNAME out/CNAME && touch out/.nojekyll && git add out/ && git commit -m \"ready to deploy\" && git push && git subtree push --prefix out origin gh-pages"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/pages/presentation.js
+++ b/pages/presentation.js
@@ -96,11 +96,6 @@ export default function Presentation() {
               </a>
               <Link
                 href="/documentation/quick-start"
-                as={
-                  (process.env.NODE_ENV === "production"
-                    ? "/material-tailwind"
-                    : "") + "/documentation/quick-start"
-                }
               >
                 <a>
                   <Button
@@ -348,11 +343,6 @@ export default function Example() {
                 </div>
                 <Link
                   href="/documentation/react/buttons/filled"
-                  as={
-                    (process.env.NODE_ENV === "production"
-                      ? "/material-tailwind"
-                      : "") + "/documentation/react/buttons/filled"
-                  }
                 >
                   <a className="font-bold text-blue-gray-900 hover:text-blue-gray-700 transition-all">
                     View All{" "}
@@ -445,12 +435,6 @@ export default function Example() {
                     </a>
                     <Link
                       href="/documentation/react/alerts"
-
-                      as={
-                        (process.env.NODE_ENV === "production"
-                          ? "/material-tailwind"
-                          : "") + "/documentation/react/alerts"
-                      }
                     >
                       <a>
                         <div className="bg-light-blue-500 shadow-xl rounded-lg text-center p-8 mt-8">
@@ -563,11 +547,6 @@ export default function Example() {
                 </div>
                 <Link
                   href="/documentation/react/alerts"
-                  as={
-                    (process.env.NODE_ENV === "production"
-                      ? "/material-tailwind"
-                      : "") + "/documentation/react/alerts"
-                  }
                 >
                   <a className="font-bold text-blue-gray-900 hover:text-blue-gray-700 transition-all">
                     View all{" "}
@@ -741,11 +720,6 @@ export default function Example() {
               <div className="flex justify-center gap-4 mt-10">
                 <Link
                   href="/documentation/quick-start"
-                  as={
-                    (process.env.NODE_ENV === "production"
-                      ? "/material-tailwind"
-                      : "") + "/documentation/quick-start"
-                  }
                 >
                   <a>
                     <Button color="lightBlue" size="lg" ripple="light">

--- a/pagesComponents/IndexNavbar.js
+++ b/pagesComponents/IndexNavbar.js
@@ -13,11 +13,6 @@ export default function IndexNavbar(props) {
         <div className="w-full relative flex justify-between lg:w-auto lg:static lg:block lg:justify-start">
           <Link
             href="/"
-            as={
-              (process.env.NODE_ENV === "production"
-                ? "/material-tailwind"
-                : "") + "/"
-            }
           >
             <a className="text-gray-900 text-sm font-bold leading-relaxed inline-block mr-4 py-2 whitespace-no-wrap uppercase">
               Material Tailwind
@@ -45,11 +40,6 @@ export default function IndexNavbar(props) {
             >
               <Link
                 href="/documentation/quick-start"
-                as={
-                  (process.env.NODE_ENV === "production"
-                    ? "/material-tailwind"
-                    : "") + "/documentation/quick-start"
-                }
               >
                 <a className="px-3 py-4 lg:py-2 flex items-center text-xs uppercase font-bold">
                   <i className="far fa-file-alt text-lg leading-lg " />
@@ -63,11 +53,6 @@ export default function IndexNavbar(props) {
             >
               <Link
                 href="/components"
-                as={
-                  (process.env.NODE_ENV === "production"
-                    ? "/material-tailwind"
-                    : "") + "/components"
-                }
               >
                 <a className="px-3 py-4 lg:py-2 flex items-center text-xs uppercase font-bold">
                   <i className="fas fa-cubes text-lg leading-lg " />


### PR DESCRIPTION
This PR changes the live setting so that the live preview/website is hosted at material-tailwind.com instead of demos.creative-tim.com/material-tailwind