### PR TITLE
fix(html): menu component

### DIFF
--- a/public/material-tailwind-html.js
+++ b/public/material-tailwind-html.js
@@ -16,7 +16,6 @@ window.onload = function() {
       this.parentElement.classList.toggle('open');
 
       var dropdown_menu = document.querySelectorAll('.menu-item + .dropdown-menu');
-      console.log(dropdown_menu);
       for (var i = 0; i < dropdown_menu.length; i++) {
         var menu_item = dropdown_menu[i].previousElementSibling;
         menu_item.addEventListener('click', nestedMenuClickHandler)

--- a/public/material-tailwind-html.js
+++ b/public/material-tailwind-html.js
@@ -19,9 +19,7 @@ window.onload = function() {
       console.log(dropdown_menu);
       for (var i = 0; i < dropdown_menu.length; i++) {
         var menu_item = dropdown_menu[i].previousElementSibling;
-        menu_item.addEventListener('click', function () {
-          this.nextElementSibling.classList.toggle('open');
-        })
+        menu_item.addEventListener('click', nestedMenuClickHandler)
       }
     })
 
@@ -37,6 +35,10 @@ window.onload = function() {
       }
     });
   };
+
+  function nestedMenuClickHandler() {
+    this.nextElementSibling.classList.toggle('open');
+  }
 
   // Colored shadow
   if (document.querySelectorAll('[blur-shadow-image]')) {

--- a/public/material-tailwind-html.js
+++ b/public/material-tailwind-html.js
@@ -18,7 +18,7 @@ window.onload = function() {
       var dropdown_menu = document.querySelectorAll('.menu-item + .dropdown-menu');
       console.log(dropdown_menu);
       for (var i = 0; i < dropdown_menu.length; i++) {
-        var menu_item = dropdown_menu[i].previousSibling;
+        var menu_item = dropdown_menu[i].previousElementSibling;
         menu_item.addEventListener('click', function () {
           this.nextElementSibling.classList.toggle('open');
         })
@@ -31,7 +31,7 @@ window.onload = function() {
     }
     window.addEventListener('click', function(e) {
       if (dropdown.parentElement.classList.contains('open')) {
-        if (!dropdown.contains(e.target) && !dropdown.previousSibling.contains(e.target)){
+        if (!dropdown.contains(e.target) && !dropdown.previousElementSibling.contains(e.target)){
           close();
         }
       }


### PR DESCRIPTION
### Summary

Fixing Bug Issue described [here](https://github.com/creativetimofficial/material-tailwind/issues/124)

Fixes:
- change `element.previousSibling` to `element.previousElementSibling` to avoid TextNodes to be considered on opening the menu
- extract the nested menu handler to avoid multiple eventlisteners attached to the nested menu causing it not to open when there is an odd number of listeners attached