### PR TITLE
[fix]: [WARNING] "trasition" is not a known CSS property

### DIFF
--- a/packages/material-tailwind-html/theme/components/pagination/index.js
+++ b/packages/material-tailwind-html/theme/components/pagination/index.js
@@ -45,7 +45,7 @@ const pagination = (theme) => ({
       position: "relative",
       backgroundColor: theme("colors.white"),
       border: "1px solid #dee2e6",
-      trasition:
+      transition:
         "color .15s ease-in-out, background-color .15s ease-in-out, border-color .15s ease-in-out, box-shadow .15s ease-in-out",
 
       "&:hover": {


### PR DESCRIPTION
Vite: `^3.1.0`

fix building warning
command line:
```bash
 npm run build

> build     
> vite build

vite v3.1.0 building for production...

warn - The RTL features in Tailwind CSS are currently in preview.
warn - Preview features are not covered by semver, and may be improved in breaking ways at any time.
✓ 1 modules transformed.
warnings when minifying css:
▲ [WARNING] "trasition" is not a known CSS property [unsupported-css-property]

    <stdin>:3605:2:
      3605 │   trasition: color .15s ease-in-out, background-color .15s ease-...
           │   ~~~~~~~~~
           ╵   transition

  Did you mean "transition" instead?
```