### PR TITLE
replaced "throw" with "through"

### DIFF
--- a/documentation/react/fonts.mdx
+++ b/documentation/react/fonts.mdx
@@ -36,7 +36,7 @@ const fontFamily = {
 
 You can customize the default font families for @material-tailwind/react very easy and straightforward, it's the same as customizing font families for tailwindcss.
 
-You just need to customize the font family that you like throw the <Code>fontFamily</Code> object for <Code>tailwind.config.js</Code> file.
+You just need to customize the font family that you like through the <Code>fontFamily</Code> object for <Code>tailwind.config.js</Code> file.
 
 ```js {4}
 module.exports = withMT({

--- a/documentation/react/screens.mdx
+++ b/documentation/react/screens.mdx
@@ -40,7 +40,7 @@ const boxShadow = {
 
 You can customize the default breakpoints for @material-tailwind/react very easy and straightforward, it's the same as customizing breakpoints for tailwindcss.
 
-You just need to customize the breakpoint that you like throw the <Code>screens</Code> object for <Code>tailwind.config.js</Code> file.
+You just need to customize the breakpoint that you like through the <Code>screens</Code> object for <Code>tailwind.config.js</Code> file.
 
 ```js {4}
 module.exports = withMT({

--- a/documentation/react/shadows.mdx
+++ b/documentation/react/shadows.mdx
@@ -42,7 +42,7 @@ const boxShadow = {
 
 You can customize the default box shadow values for @material-tailwind/react very easy and straightforward, it's the same as customizing box shadow values for tailwindcss.
 
-You just need to customize the box shadow value that you like throw the <Code>boxShadow</Code> object for <Code>tailwind.config.js</Code> file.
+You just need to customize the box shadow value that you like through the <Code>boxShadow</Code> object for <Code>tailwind.config.js</Code> file.
 
 ```js {4}
 module.exports = withMT({


### PR DESCRIPTION
I think you guys meant "through," not "throw." I didn't bother making an issue because it's a simple typo. I went ahead and fixed all occurrences of this I could find.