### PR TITLE
Default config to use saner paths, fixes #213

### DIFF
--- a/packages/material-tailwind-react/src/utils/withMT.js
+++ b/packages/material-tailwind-react/src/utils/withMT.js
@@ -11,8 +11,8 @@ const breakpoints = require("../theme/base/breakpoints");
 const materialTailwindConfig = {
   darkMode: "class",
   content: [
-    "./node_modules/@material-tailwind/react/components/**/*.{js,ts,jsx,tsx}",
-    "./node_modules/@material-tailwind/react/theme/components/**/*.{js,ts,jsx,tsx}",
+    __dirname + "/../components/**/*.{js,ts,jsx,tsx}",
+    __dirname + "/../theme/components/**/*.{js,ts,jsx,tsx}",
   ],
   theme: {
     colors,


### PR DESCRIPTION
This simple fix would make the paths correct regardless of the use of NPM Workspaces.