### PR TITLE
fix: workaround for _jsx is not a function

### DIFF
--- a/pages/docs/[...slug].tsx
+++ b/pages/docs/[...slug].tsx
@@ -153,7 +153,7 @@ const components = {
   p: (props) => (
     <Typography className="!mb-4 !font-normal !text-blue-gray-500" {...props} />
   ),
-  hr: () => <hr className="!mt-16 !mb-12 border-transparent" />,
+  hr: () => <hr className="!mb-12 !mt-16 border-transparent" />,
   a: (props) => (
     <a
       className="!font-medium !text-blue-gray-900 !transition-colors hover:!text-blue-500"
@@ -348,7 +348,7 @@ export const getStaticProps = async ({ params: { slug } }) => {
     mdxOptions: {
       rehypePlugins: [[rehypePrettyCode, config]],
       remarkPlugins: [remarkGfm],
-      development: false,
+      development: process.env.NODE_ENV === "development",
     },
   });
 


### PR DESCRIPTION
 next-mdx-remote issue, see:
 https://github.com/hashicorp/next-mdx-remote/issues/350