### PR TITLE
Improve first load size

### DIFF
--- a/packages/material-tailwind-react/src/components/Accordion/AccordionBody.tsx
+++ b/packages/material-tailwind-react/src/components/Accordion/AccordionBody.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 // framer-motion
-import { motion, MotionProps } from "framer-motion";
+import { m, MotionProps } from "framer-motion";
 
 // utils
 import classnames from "classnames";
@@ -63,14 +63,14 @@ export const AccordionBody = React.forwardRef<HTMLDivElement, AccordionBodyProps
 
     // 5. return
     return (
-      <motion.div
+      <m.div
         className="overflow-hidden"
         initial="unmount"
         exit="unmount"
         animate={open ? "mount" : "unmount"}
         variants={heightAnimation}
       >
-        <motion.div
+        <m.div
           {...rest}
           ref={ref}
           className={bodyClasses}
@@ -80,8 +80,8 @@ export const AccordionBody = React.forwardRef<HTMLDivElement, AccordionBodyProps
           variants={appliedAnimation}
         >
           {children}
-        </motion.div>
-      </motion.div>
+        </m.div>
+      </m.div>
     );
   },
 );

--- a/packages/material-tailwind-react/src/components/Alert/index.tsx
+++ b/packages/material-tailwind-react/src/components/Alert/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 
 // framer-motion
-import { AnimatePresence, motion, MotionProps } from "framer-motion";
+import { AnimatePresence, m, MotionProps } from "framer-motion";
 
 // utils
 import Ripple from "material-ripple-effects";
@@ -18,24 +18,24 @@ import { useTheme } from "../../context/theme";
 // types
 import type { NewAnimatePresenceProps } from "../../types/generic";
 import type {
-  variant,
+  animate,
+  children,
+  className,
   color,
+  dismissible,
   icon,
   show,
-  dismissible,
-  animate,
-  className,
-  children,
+  variant,
 } from "../../types/components/alert";
 import {
-  propTypesVariant,
+  propTypesAnimate,
+  propTypesChildren,
+  propTypesClassName,
   propTypesColor,
+  propTypesDismissible,
   propTypesIcon,
   propTypesShow,
-  propTypesDismissible,
-  propTypesAnimate,
-  propTypesClassName,
-  propTypesChildren,
+  propTypesVariant,
 } from "../../types/components/alert";
 
 export interface AlertProps extends Omit<MotionProps, "animate"> {
@@ -85,7 +85,7 @@ export const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
     const appliedAnimation = merge(mainAnimation, animate);
 
     // 5. icon template
-    const iconTemplate = <div className="absolute top-4 left-4">{icon}</div>;
+    const iconTemplate = <div className="absolute left-4 top-4">{icon}</div>;
 
     // 6. Create an instance of AnimatePresence because of the types issue with the children
     const NewAnimatePresence: React.FC<NewAnimatePresenceProps> = AnimatePresence;
@@ -94,7 +94,7 @@ export const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
     return (
       <NewAnimatePresence>
         {show && (
-          <motion.div
+          <m.div
             {...rest}
             ref={ref}
             role="alert"
@@ -107,12 +107,12 @@ export const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
             {icon && iconTemplate}
             <div className={`${icon ? "ml-8" : ""} mr-12`}>{children}</div>
             {dismissible && (
-              <div className="absolute top-3 right-3 w-max rounded-lg hover:bg-white hover:bg-opacity-20 transition-all">
+              <div className="absolute right-3 top-3 w-max rounded-lg transition-all hover:bg-white hover:bg-opacity-20">
                 <div
                   role="button"
                   onClick={dismissible.onClose}
                   onMouseDown={(e) => !dismissible.action && rippleEffect.create(e, "light")}
-                  className={`w-max ${dismissible.action ? "" : "p-1 rounded-lg"}`}
+                  className={`w-max ${dismissible.action ? "" : "rounded-lg p-1"}`}
                 >
                   {dismissible.action || (
                     <svg
@@ -129,7 +129,7 @@ export const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
                 </div>
               </div>
             )}
-          </motion.div>
+          </m.div>
         )}
       </NewAnimatePresence>
     );

--- a/packages/material-tailwind-react/src/components/Chip/index.tsx
+++ b/packages/material-tailwind-react/src/components/Chip/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 
 // framer-motion
-import { AnimatePresence, motion, MotionProps } from "framer-motion";
+import { AnimatePresence, m, MotionProps } from "framer-motion";
 
 // utils
 import Ripple from "material-ripple-effects";
@@ -104,7 +104,7 @@ export const Chip = React.forwardRef<HTMLDivElement, ChipProps>(
     return (
       <NewAnimatePresence>
         {show && (
-          <motion.div
+          <m.div
             {...rest}
             ref={ref}
             className={classes}
@@ -123,7 +123,7 @@ export const Chip = React.forwardRef<HTMLDivElement, ChipProps>(
                   role="button"
                   onClick={dismissible.onClose}
                   onMouseDown={(e) => !dismissible.action && rippleEffect.create(e, "light")}
-                  className={`w-5 h-5 ${dismissible.action ? "" : "p-1"}`}
+                  className={`h-5 w-5 ${dismissible.action ? "" : "p-1"}`}
                 >
                   {dismissible.action || (
                     <svg
@@ -139,7 +139,7 @@ export const Chip = React.forwardRef<HTMLDivElement, ChipProps>(
                 </div>
               </div>
             )}
-          </motion.div>
+          </m.div>
         )}
       </NewAnimatePresence>
     );

--- a/packages/material-tailwind-react/src/components/Dialog/index.tsx
+++ b/packages/material-tailwind-react/src/components/Dialog/index.tsx
@@ -16,7 +16,7 @@ import {
 } from "@floating-ui/react";
 
 // framer-motion
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence, m } from "framer-motion";
 
 // utils
 import classnames from "classnames";
@@ -154,7 +154,7 @@ const Dialog = React.forwardRef<HTMLDivElement, DialogProps>(
               lockScroll
             >
               <FloatingFocusManager context={context}>
-                <motion.div
+                <m.div
                   className={size === "xxl" ? "" : backdropClasses}
                   initial="unmount"
                   exit="unmount"
@@ -162,7 +162,7 @@ const Dialog = React.forwardRef<HTMLDivElement, DialogProps>(
                   variants={backdropAnimation}
                   transition={{ duration: 0.2 }}
                 >
-                  <motion.div
+                  <m.div
                     {...getFloatingProps({
                       ...rest,
                       ref: mergedRef,
@@ -176,8 +176,8 @@ const Dialog = React.forwardRef<HTMLDivElement, DialogProps>(
                     variants={appliedAnimation}
                   >
                     {children}
-                  </motion.div>
-                </motion.div>
+                  </m.div>
+                </m.div>
               </FloatingFocusManager>
             </FloatingOverlay>
           )}

--- a/packages/material-tailwind-react/src/components/Menu/MenuList.tsx
+++ b/packages/material-tailwind-react/src/components/Menu/MenuList.tsx
@@ -7,7 +7,7 @@ import {
   FloatingFocusManager,
   useMergeRefs,
 } from "@floating-ui/react";
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence, m } from "framer-motion";
 
 // utils
 import classnames from "classnames";
@@ -69,7 +69,7 @@ export const MenuList = React.forwardRef<HTMLUListElement, MenuListProps>(
 
     // 6. menu component
     const menuComponent = (
-      <motion.div
+      <m.div
         {...rest}
         ref={mergedRef}
         style={{
@@ -119,7 +119,7 @@ export const MenuList = React.forwardRef<HTMLUListElement, MenuListProps>(
               }),
             ),
         )}
-      </motion.div>
+      </m.div>
     );
 
     // 7. return

--- a/packages/material-tailwind-react/src/components/Navbar/MobileNav.tsx
+++ b/packages/material-tailwind-react/src/components/Navbar/MobileNav.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 // framer-motion components
-import { AnimatePresence, AnimatePresenceProps, motion, MotionProps } from "framer-motion";
+import { AnimatePresence, AnimatePresenceProps, m, MotionProps } from "framer-motion";
 
 // @floating-ui
 import { useMergeRefs } from "@floating-ui/react";
@@ -80,7 +80,7 @@ export const MobileNav = React.forwardRef<HTMLDivElement, MobileNavProps>(
     // 6. return
     return (
       <NewAnimatePresence>
-        <motion.div
+        <m.div
           {...rest}
           ref={mergedRef}
           className={classes}
@@ -90,7 +90,7 @@ export const MobileNav = React.forwardRef<HTMLDivElement, MobileNavProps>(
           variants={appliedAnimation}
         >
           {children}
-        </motion.div>
+        </m.div>
       </NewAnimatePresence>
     );
   },

--- a/packages/material-tailwind-react/src/components/Popover/PopoverContent.tsx
+++ b/packages/material-tailwind-react/src/components/Popover/PopoverContent.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import { FloatingPortal, FloatingFocusManager, useMergeRefs } from "@floating-ui/react";
 
 // framer-motion
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence, m } from "framer-motion";
 
 // utils
 import classnames from "classnames";
@@ -64,7 +64,7 @@ export const PopoverContent = React.forwardRef<HTMLDivElement, PopoverContentPro
         <NewAnimatePresence>
           {open && (
             <FloatingFocusManager context={context}>
-              <motion.div
+              <m.div
                 {...getFloatingProps({
                   ...rest,
                   ref: mergedRef,
@@ -83,7 +83,7 @@ export const PopoverContent = React.forwardRef<HTMLDivElement, PopoverContentPro
                 variants={appliedAnimation}
               >
                 {children}
-              </motion.div>
+              </m.div>
             </FloatingFocusManager>
           )}
         </NewAnimatePresence>

--- a/packages/material-tailwind-react/src/components/Select/index.tsx
+++ b/packages/material-tailwind-react/src/components/Select/index.tsx
@@ -19,7 +19,7 @@ import {
 } from "@floating-ui/react";
 
 // framer-motion
-import { AnimatePresence, motion, useIsomorphicLayoutEffect } from "framer-motion";
+import { AnimatePresence, m, useIsomorphicLayoutEffect } from "framer-motion";
 
 // utils
 import classnames from "classnames";
@@ -350,7 +350,7 @@ const Select = React.forwardRef<HTMLDivElement, SelectProps>(
     // 8. select menu
     const selectMenu = (
       <FloatingFocusManager context={context} modal={false}>
-        <motion.ul
+        <m.ul
           {...getFloatingProps({
             ...menuProps,
             ref: refs.setFloating,
@@ -402,7 +402,7 @@ const Select = React.forwardRef<HTMLDivElement, SelectProps>(
                 id: `material-tailwind-select-${index}`,
               }),
           )}
-        </motion.ul>
+        </m.ul>
       </FloatingFocusManager>
     );
 

--- a/packages/material-tailwind-react/src/components/Tabs/Tab.tsx
+++ b/packages/material-tailwind-react/src/components/Tabs/Tab.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 // framer-motion
-import { motion } from "framer-motion";
+import { m } from "framer-motion";
 
 // utils
 import classnames from "classnames";
@@ -78,7 +78,7 @@ export const Tab = React.forwardRef<HTMLLIElement, TabProps>(
       >
         <div className="z-20">{children}</div>
         {active === value && (
-          <motion.div
+          <m.div
             {...indicatorProps}
             transition={{ duration: 0.5 }}
             className={indicatorClasses}

--- a/packages/material-tailwind-react/src/components/Tabs/TabPanel.tsx
+++ b/packages/material-tailwind-react/src/components/Tabs/TabPanel.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 
 // framer-motion
-import { motion, AnimatePresence, MotionProps } from "framer-motion";
+import { AnimatePresence, m, MotionProps } from "framer-motion";
 
 // utils
 import classnames from "classnames";
@@ -47,7 +47,7 @@ export const TabPanel = React.forwardRef<HTMLDivElement, TabPanelProps>(
     // 5. return
     return (
       <NewAnimatePresence exitBeforeEnter>
-        <motion.div
+        <m.div
           {...rest}
           ref={ref}
           role="tabpanel"
@@ -59,7 +59,7 @@ export const TabPanel = React.forwardRef<HTMLDivElement, TabPanelProps>(
           data-value={value}
         >
           {children}
-        </motion.div>
+        </m.div>
       </NewAnimatePresence>
     );
   },

--- a/packages/material-tailwind-react/src/components/Tooltip/index.tsx
+++ b/packages/material-tailwind-react/src/components/Tooltip/index.tsx
@@ -19,7 +19,7 @@ import {
 } from "@floating-ui/react";
 
 // framer-motion
-import { AnimatePresence, motion } from "framer-motion";
+import {AnimatePresence, m} from "framer-motion";
 
 // utils
 import classnames from "classnames";
@@ -57,6 +57,7 @@ import {
   propTypesChildren,
 } from "../../types/components/popover";
 
+// @ts-ignore
 export interface TooltipProps extends React.ComponentProps<"div"> {
   open?: open;
   handler?: handler;
@@ -171,7 +172,7 @@ export const Tooltip = React.forwardRef<HTMLDivElement, TooltipProps>(
         <FloatingPortal>
           <NewAnimatePresence>
             {open && (
-              <motion.div
+              <m.div
                 {...getFloatingProps({
                   ...rest,
                   ref: mergedRef,
@@ -188,7 +189,7 @@ export const Tooltip = React.forwardRef<HTMLDivElement, TooltipProps>(
                 variants={appliedAnimation}
               >
                 {content}
-              </motion.div>
+              </m.div>
             )}
           </NewAnimatePresence>
         </FloatingPortal>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -8,13 +8,16 @@ import { ThemeProvider } from "@material-tailwind/react";
 
 // styles
 import "/styles/globals.css";
+import { domAnimation, LazyMotion } from "framer-motion";
 
 function MyApp({ Component, pageProps }) {
   return (
     <Fragment>
-      <ThemeProvider>
-        <Component {...pageProps} />
-      </ThemeProvider>
+      <LazyMotion features={domAnimation}>
+        <ThemeProvider>
+          <Component {...pageProps} />
+        </ThemeProvider>
+      </LazyMotion>
       <Script id="google-analytics" strategy="afterInteractive">
         {`
           (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KB2WKJS');


### PR DESCRIPTION
Hi,
first of all sorry for the delay, I change some code to decrease framer motion first load size and this is the result 
### Before:
![before](https://user-images.githubusercontent.com/31635962/236619557-e5592f24-30cd-4458-863b-ddab55201b5f.png)
### After
![after1](https://user-images.githubusercontent.com/31635962/236620877-749165a0-c435-440a-ab02-eb6481328386.png)


To use this feature developer must use components inside the LazyMotion component so I add this component to the _app.
also, we can add this component to ThemeProvider but it's better to use the LazyMotion component just where it's needed!
it's up to you feel free to change.

[full guide](https://www.framer.com/motion/guide-reduce-bundle-size/#how-to-reduce-the-size-of-the-motion-component)