### PR TITLE
Fix grammar in button documentation

### DIFF
--- a/documentation/html/button.mdx
+++ b/documentation/html/button.mdx
@@ -434,7 +434,7 @@ You can use any type of icons inside the button, in the below example we've used
 
 ### Block Level Button
 
-A button could be a block level component as well that get's all the available space in a row. You can render a button as a block level element using the <Code html>w-full</Code> class.
+A button could be a block-level component as well that gets all the available space in a row. You can render a button as a block-level element using the <Code html>w-full</Code> class.
 
 <CodePreview
   id="block-level-button"

--- a/documentation/react/button.mdx
+++ b/documentation/react/button.mdx
@@ -213,7 +213,7 @@ export default function Day01() {
 ## Block Level Button
 </DocsTitle>
 
-A <Code>Button</Code> could be a block level component as well that get's all the available space in a row. You can render a <Code>Button</Code> as a block level element using the <Code>fullWidth</Code> prop.
+A <Code>Button</Code> could be a block-level component as well that gets all the available space in a row. You can render a <Code>Button</Code> as a block-level element using the <Code>fullWidth</Code> prop.
 
 <CodePreview id="block-level-button" link="button#block-level-button" component={<Button fullWidth>block level button</Button>}>
 ```jsx


### PR DESCRIPTION
The original sentence had a grammatical error where "get's" was used instead of "gets." This pull request corrects the error