### PR TITLE
Next.js guide improvement

### DIFF
--- a/documentation/react/guide/next.mdx
+++ b/documentation/react/guide/next.mdx
@@ -103,12 +103,12 @@ module.exports = withMT({
 ---
 
 <DocsTitle href="with-server-components">
-## With Next.js 13 appDir and Server Components
+## With Next.js 13 App Router and Server Components
 </DocsTitle>
 
 <span id="with-server-components" className="scroll-mt-48" />
 
-If you want to use @material-tailwind/react with the Next.js 13 appDir feature, you need to make use of the <br /> <Code>'use client'</Code> directive since many Material Tailwind components can only be rendered on the client side. A simple approach is to re-export or wrap Material Tailwind components in your own components.
+If you want to use @material-tailwind/react with the Next.js 13 App Router, you need to make use of the <br /> <Code>'use client'</Code> directive since many Material Tailwind components can only be rendered on the client side. A simple approach is to re-export or wrap Material Tailwind components in your own components.
 
 ```js
 "use client";
@@ -141,7 +141,7 @@ import { Button } from "path/to/the/new/file";
 
 @material-tailwind/react comes with a theme provider that sets the default or custom theme/styles for Material Tailwind components. Wrap your entire application with the <Code>ThemeProvider</Code> component from @material-tailwind/react. The file to add this to depends on your Next.js setup:
 
-With the App Router: <Code>app/layout</Code>
+With the App Router: <Code>app/layout</Code>  
 With the Pages Router: <Code>pages/\_app</Code>
 
 ```jsx {3, 7, 9}

--- a/documentation/react/guide/next.mdx
+++ b/documentation/react/guide/next.mdx
@@ -1,5 +1,5 @@
 ---
-title: Next.JS - Installation Guide
+title: Next.js - Installation Guide
 description: Learn how to use Material Tailwind components with Next.js and Tailwind CSS to easily create elegant and flexible pages.
 navigation:
   [

--- a/documentation/react/guide/next.mdx
+++ b/documentation/react/guide/next.mdx
@@ -26,7 +26,7 @@ Learn how to setup and install @material-tailwind/react with Next.js.
 <br />
 <br />
 
-First you need to create a new project using next.js, for more details check the <a target="_blank" className="font-medium hover:text-blue-500 transition-colors" href="https://nextjs.org/docs/getting-started?ref=material-tailwind">Next.JS Official Documentation</a>
+First, create a new Next.js project using the command below. When asked if you want to use Tailwind CSS with your project, select "Yes" so that it's automatically installed and set up for you. For more details check the <a target="_blank" className="font-medium hover:text-blue-500 transition-colors" href="https://nextjs.org/docs/getting-started/installation?ref=material-tailwind">Next.js Official Documentation</a>.
 
 ```bash
 npx create-next-app@latest
@@ -34,8 +34,7 @@ npx create-next-app@latest
 
 <br />
 
-Then you need to install Tailwind CSS since @material-tailwind/react is working with Tailwind CSS classes and you need to have Tailwind CSS installed on your project.
-Check <a href="https://tailwindcss.com/docs/guides/nextjs?ref=material-tailwind" target="_blank" className="font-medium hover:text-blue-500 transition-colors">Tailwind CSS Installation</a> for next.js on Tailwind CSS Documentation.
+If you have an existing Next.js project and need to install Tailwind CSS manually, check the guide in the <a href="https://tailwindcss.com/docs/guides/nextjs?ref=material-tailwind" target="_blank" className="font-medium hover:text-blue-500 transition-colors">Tailwind CSS documentation</a>.
 
 ---
 
@@ -82,12 +81,12 @@ pnpm i @material-tailwind/react
 ---
 
 <DocsTitle href="tailwindcss-config">
-## TailwindCSS Configurations
+## Tailwind CSS Configuration
 </DocsTitle>
 
 <span id="tailwindcss-config" className="scroll-mt-48" />
 
-Once you install @material-tailwind/react you need to wrap your tailwind css configurations with the <Code>withMT()</Code> function coming from @material-tailwind/react/utils on the <Code>tailwind.config.js</Code> file.
+Once you install @material-tailwind/react, you need to wrap your Tailwind CSS configuration with the <Code>withMT()</Code> function from @material-tailwind/react/utils in your <Code>tailwind.config.js</Code> file.
 
 ```js {1, 3, 9}
 const withMT = require("@material-tailwind/react/utils/withMT");
@@ -103,39 +102,13 @@ module.exports = withMT({
 
 ---
 
-<DocsTitle href="with-monorepo">
-## TailwindCSS Configurations with MonoRepo
-</DocsTitle>
-
-<span id="with-monorepo" className="scroll-mt-48" />
-
-If you're using monorepo in your project you need to add the theme and components paths to your tailwind.config.js.
-
-```js {6,7}
-const withMT = require("@material-tailwind/react/utils/withMT");
-
-module.exports = withMT({
-  content: [
-    "./pages/**/*.{js,ts,jsx,tsx}",
-    "path-to-your-node_modules/@material-tailwind/react/components/**/*.{js,ts,jsx,tsx}",
-    "path-to-your-node_modules/@material-tailwind/react/theme/components/**/*.{js,ts,jsx,tsx}",
-  ],
-  theme: {
-    extend: {},
-  },
-  plugins: [],
-});
-```
-
----
-
 <DocsTitle href="with-server-components">
 ## With Next.js 13 appDir and Server Components
 </DocsTitle>
 
 <span id="with-server-components" className="scroll-mt-48" />
 
-If you want to use @material-tailwind/react with Next.js 13 appDir feature you need to make use of the <br /> <Code>'use client'</Code> to makes it possible a simple approach is to make a new export file for the components you want to use from @material-tailwind/react
+If you want to use @material-tailwind/react with the Next.js 13 appDir feature, you need to make use of the <br /> <Code>'use client'</Code> directive since many Material Tailwind components can only be rendered on the client side. A simple approach is to re-export or wrap Material Tailwind components in your own components.
 
 ```js
 "use client";
@@ -148,14 +121,13 @@ export { ThemeProvider, Button };
 <br />
 <br />
 
-Once you've created the export file for the components now you need to import the
-components you want to use from that new created file rather than @material-tailwind/react.
+Once you've re-exported or wrapped any Material Tailwind components you need, simply point all imports to the new files.
 
 ```js
-// ❌ invalid - this is not working with server components
+// ❌ invalid - this will not work on the client side
 import { Button } from "@material-tailwind/react";
 
-// ✅ valid - this will work fine with server components
+// ✅ valid - this will work on the client side
 import { Button } from "path/to/the/new/file";
 ```
 
@@ -167,9 +139,10 @@ import { Button } from "path/to/the/new/file";
 
 <span id="theme-provider" className="scroll-mt-48" />
 
-@material-tailwind/react comes with a theme provider that set's the default theme/styles for components or to provide your own theme/styles to your components. You need to wrap your entire application with the <Code>ThemeProvider</Code> coming from @material-tailwind/react.
+@material-tailwind/react comes with a theme provider that sets the default or custom theme/styles for Material Tailwind components. Wrap your entire application with the <Code>ThemeProvider</Code> component from @material-tailwind/react. The file to add this to depends on your Next.js setup:
 
-On the <Code>pages/\_app</Code> put the code bellow.
+With the App Router: <Code>app/layout</Code>
+With the Pages Router: <Code>pages/\_app</Code>
 
 ```jsx {3, 7, 9}
 import "/styles/globals.css";
@@ -187,18 +160,4 @@ export default function MyApp({ Component, pageProps }) {
 
 ---
 
-<DocsTitle href="example">
-## Example
-</DocsTitle>
-
-Now you're good to go and use @material-tailwind/react in your project.
-
-<CodePreview id="example" component={<Button>Button</Button>}>
-```jsx
-import { Button } from "@material-tailwind/react";
-
-export default function Example() {
-  return <Button>Button</Button>;
-}
-```
-</CodePreview>
+Now your Next.js project is ready to use Material Tailwind components.

--- a/documentation/react/input.mdx
+++ b/documentation/react/input.mdx
@@ -490,7 +490,7 @@ type size = "md" | "lg";
 
 ```ts
 type color =
-  | "blakc"
+  | "black"
   | "white"
   | "blue-gray"
   | "gray"


### PR DESCRIPTION
I found the Next.js setup guide difficult to understand.

- Clarifies several key steps (e.g., App Router vs. Pages Router)
- Removes a few sections irrelevant to this guide or unnecessary in general
- Improves grammar
- Improves formatting

Also fixes a spelling mistake in the Input colors list.