### PR TITLE
Fix typo of collpase to collapse

### DIFF
--- a/docs-content/react/releases.ts
+++ b/docs-content/react/releases.ts
@@ -169,7 +169,7 @@ export const releases = [
         data: [
           "Add new component Badge",
           "Add new component ButtonGroup",
-          "Add new component Collpase",
+          "Add new component Collapse",
           "Add new component Carousel",
           "Add new component Drawer",
           "Add new component List",
@@ -388,7 +388,7 @@ export const releases = [
       },
       {
         title: "features",
-        data: ["Add MobileNav component for responsive Navbar collpase."],
+        data: ["Add MobileNav component for responsive Navbar collapse."],
       },
       {
         title: "updates",

--- a/routes/react.routes.ts
+++ b/routes/react.routes.ts
@@ -131,7 +131,7 @@ export const routes = [
         route: "chip",
       },
       {
-        name: "Collpase",
+        name: "Collapse",
         route: "collapse",
       },
       {


### PR DESCRIPTION
### Changes:
* This fixes a typo that I noticed while using material tailwind. It should read "Collapse" instead of "Collpase"

### Comments
* I was not sure if I needed to change the spelling in the `releases.ts` file or not, so feel free to change that if needed! (I did go ahead and do it)