### PR TITLE
Fix typo in page-map.tsx

### DIFF
--- a/widgets/layout/page-map.tsx
+++ b/widgets/layout/page-map.tsx
@@ -117,7 +117,7 @@ export function PageMap({ type, frontMatter }) {
               className="relative list-item w-full py-1 text-sm capitalize text-gray-600 transition-colors hover:text-primary focus:text-primary"
               rel="noreferrer"
             >
-              Join un on Discord
+              Join us on Discord
             </a>
           </li>
           <li>


### PR DESCRIPTION
**Changes :**

This fixes a small typo to "Join us to Discord" instead of "Join un to Discord".