### PR TITLE
Fix: add containerProps to Select Props section

### DIFF
--- a/documentation/react/select.mdx
+++ b/documentation/react/select.mdx
@@ -351,28 +351,29 @@ The following props are available for select component. These are the custom pro
 that we've added for the select component and you can use all the other
 native props as well.
 
-| Attribute    | Type                      | Description                                     | Default                                |
-| ------------ | ------------------------- | ----------------------------------------------- | -------------------------------------- |
-| `variant`    | [Variant](#types-variant) | Change select variant                           | <Code>outlined</Code>                  |
-| `size`       | [Size](#types-size)       | Change select size                              | <Code>md</Code>                        |
-| `color`      | [Color](#types-color)     | Change select color                             | <Code>gray</Code>                      |
-| `label`      | <Code>string</Code>       | Add label for select                            | `''`                                   |
-| `error`      | <Code>boolean</Code>      | Change select state to error                    | <Code>false</Code>                     |
-| `success`    | <Code>boolean</Code>      | Change select state to success                  | <Code>false</Code>                     |
-| `arrow`      | <Code>node</Code>         | Change select arrow icon                        | <Code>undefined</Code>                 |
-| `value`      | <Code>string</Code>       | Change selected value for select                | <Code>undefined</Code>                 |
-| `onChange`   | <Code>function</Code>     | Return selected value when select value changed | <Code>undefined</Code>                 |
-| `selected`   | <Code>function</Code>     | Return selected element and it's index          | <Code>undefined</Code>                 |
-| `offset`     | [Offset](#types-offset)   | Change select menu offset from it's input       | <Code>5</Code>                         |
-| `dismiss`    | [Dismiss](#types-dismiss) | Change dismiss listeners when clicking outside  | <Code>undefined</Code>                 |
-| `animate`    | [Animate](#types-animate) | Change select menu animation                    | <Code>undefined</Code>                 |
-| `lockScroll` | <Code>boolean</Code>      | Lock page scrolling when select menu is opened  | <Code>false</Code>                     |
-| `labelProps` | <Code>object</Code>       | Add custom props for select label               | <Code>undefined</Code>                 |
-| `menuProps`  | <Code>object</Code>       | Add custom props for select menu                | <Code>undefined</Code>                 |
-| `disabled`   | <Code>boolean</Code>      | Disable select                                  | <Code>false</Code>                     |
-| `name`       | <Code>string</Code>       | Add name for select                             | <Code>false</Code>                     |
-| `className`  | <Code>string</Code>       | Add custom className for select                 | `''`                                   |
-| `children`   | <Code>node</Code>         | Add content for select                          | No default value it's a required prop. |
+| Attribute         | Type                      | Description                                     | Default                                |
+| ----------------- | ------------------------- | ----------------------------------------------- | -------------------------------------- |
+| `variant`         | [Variant](#types-variant) | Change select variant                           | <Code>outlined</Code>                  |
+| `size`            | [Size](#types-size)       | Change select size                              | <Code>md</Code>                        |
+| `color`           | [Color](#types-color)     | Change select color                             | <Code>gray</Code>                      |
+| `label`           | <Code>string</Code>       | Add label for select                            | `''`                                   |
+| `error`           | <Code>boolean</Code>      | Change select state to error                    | <Code>false</Code>                     |
+| `success`         | <Code>boolean</Code>      | Change select state to success                  | <Code>false</Code>                     |
+| `arrow`           | <Code>node</Code>         | Change select arrow icon                        | <Code>undefined</Code>                 |
+| `value`           | <Code>string</Code>       | Change selected value for select                | <Code>undefined</Code>                 |
+| `onChange`        | <Code>function</Code>     | Return selected value when select value changed | <Code>undefined</Code>                 |
+| `selected`        | <Code>function</Code>     | Return selected element and it's index          | <Code>undefined</Code>                 |
+| `offset`          | [Offset](#types-offset)   | Change select menu offset from it's input       | <Code>5</Code>                         |
+| `dismiss`         | [Dismiss](#types-dismiss) | Change dismiss listeners when clicking outside  | <Code>undefined</Code>                 |
+| `animate`         | [Animate](#types-animate) | Change select menu animation                    | <Code>undefined</Code>                 |
+| `lockScroll`      | <Code>boolean</Code>      | Lock page scrolling when select menu is opened  | <Code>false</Code>                     |
+| `containerProps`  | <Code>object</Code>       | Add custom props for select container           | <Code>undefined</Code>                 |
+| `labelProps`      | <Code>object</Code>       | Add custom props for select label               | <Code>undefined</Code>                 |
+| `menuProps`       | <Code>object</Code>       | Add custom props for select menu                | <Code>undefined</Code>                 |
+| `disabled`        | <Code>boolean</Code>      | Disable select                                  | <Code>false</Code>                     |
+| `name`            | <Code>string</Code>       | Add name for select                             | <Code>false</Code>                     |
+| `className`       | <Code>string</Code>       | Add custom className for select                 | `''`                                   |
+| `children`        | <Code>node</Code>         | Add content for select                          | No default value it's a required prop. |
 
 <br />
 <br />


### PR DESCRIPTION
Motivation: I missed this prop until I checked out the Select implementation.

Change: only added the `containerProps` line, the rest is just adding spaces.

<img width="1434" alt="Screen Shot 2023-09-17 at 01 58 48" src="https://github.com/creativetimofficial/material-tailwind/assets/6545554/47e14f8f-1983-4a50-8f4d-f6954406ec3f">
