### PR TITLE
Fix 'Scrips' to 'Scripts' where misspelled

### DIFF
--- a/documentation/html/accordion.mdx
+++ b/documentation/html/accordion.mdx
@@ -486,7 +486,7 @@ The following data attributes are available for accordion element.
 
 ---
 
-## Required Scrips
+## Required Scripts
 
 <span id="required-script" className="scroll-mt-56" />
 

--- a/documentation/html/alert.mdx
+++ b/documentation/html/alert.mdx
@@ -449,7 +449,7 @@ that you want to close the alert with).
 
 ---
 
-## Required Scrips
+## Required Scripts
 
 <span id="required-script" className="scroll-mt-56" />
 

--- a/documentation/html/button.mdx
+++ b/documentation/html/button.mdx
@@ -572,7 +572,7 @@ You can use tailwind css classes with <Code html>Button</Code> to create beautif
 
 ---
 
-## Required Scrips
+## t
 
 <span id="required-script" className="scroll-mt-56" />
 

--- a/documentation/html/checkbox.mdx
+++ b/documentation/html/checkbox.mdx
@@ -838,7 +838,7 @@ See below our easy-to-use checkbox component that you can use for your Tailwind 
 
 ---
 
-## Required Scrips
+## Required Scripts
 
 <span id="required-script" className="scroll-mt-56" />
 

--- a/documentation/html/chip.mdx
+++ b/documentation/html/chip.mdx
@@ -325,7 +325,7 @@ that you want to close the chip with).
 
 ---
 
-## Required Scrips
+## Required Scripts
 
 <span id="required-script" className="scroll-mt-56" />
 

--- a/documentation/html/dialog.mdx
+++ b/documentation/html/dialog.mdx
@@ -1624,7 +1624,7 @@ The following data attributes are available for dialog element.
 
 ---
 
-## Required Scrips
+## Required Scripts
 
 <span id="required-script" className="scroll-mt-56" />
 

--- a/documentation/html/icon-button.mdx
+++ b/documentation/html/icon-button.mdx
@@ -336,7 +336,7 @@ You can turn on/off the ripple effect for the icon button component by changing 
 
 ---
 
-## Required Scrips
+## Required Scripts
 
 <span id="required-script" className="scroll-mt-56" />
 

--- a/documentation/html/menu.mdx
+++ b/documentation/html/menu.mdx
@@ -819,7 +819,7 @@ The menu element uses the <Link href="/docs/html/popover#popover-data-attributes
 
 ---
 
-## Required Scrips
+## Required Scripts
 
 <span id="required-script" className="scroll-mt-56" />
 

--- a/documentation/html/popover.mdx
+++ b/documentation/html/popover.mdx
@@ -862,7 +862,7 @@ The following data attributes are available for popover element.
 
 ---
 
-## Required Scrips
+## Required Scripts
 
 <span id="required-script" className="scroll-mt-56" />
 

--- a/documentation/html/radio-button.mdx
+++ b/documentation/html/radio-button.mdx
@@ -689,7 +689,7 @@ Use the following example to create simple radio buttons for your projects.
 
 ---
 
-## Required Scrips
+## ts
 
 <span id="required-script" className="scroll-mt-56" />
 

--- a/documentation/html/switch.mdx
+++ b/documentation/html/switch.mdx
@@ -555,7 +555,7 @@ Use the following example to create a simple and easy-to-use switch component fo
 
 ---
 
-## Required Scrips
+## Required Scripts
 
 <span id="required-script" className="scroll-mt-56" />
 

--- a/documentation/html/tooltip.mdx
+++ b/documentation/html/tooltip.mdx
@@ -514,7 +514,7 @@ The following data attributes are available for tooltip element.
 
 ---
 
-## Required Scrips
+## Required Scripts
 
 <span id="required-script" className="scroll-mt-56" />
 


### PR DESCRIPTION
### Changes:
* This changes 'Required Scrips' to 'Required Scripts' on the documentation site as it was misspelled.