### PR TITLE
fix props spreading in Select/index.tsx

### DIFF
--- a/packages/material-tailwind-react/src/components/Select/index.tsx
+++ b/packages/material-tailwind-react/src/components/Select/index.tsx
@@ -409,11 +409,10 @@ const Select = React.forwardRef<HTMLDivElement, SelectProps>(
     // 9. return
     return (
       <SelectContextProvider value={contextValue}>
-        <div ref={ref} className={containerClasses}>
+        <div ref={ref} {...rest} className={containerClasses}>
           <button
             type="button"
             {...getReferenceProps({
-              ...rest,
               ref: refs.setReference,
               className: selectClasses,
               disabled: disabled,


### PR DESCRIPTION
Since the Select Component is typed as div, the props should be spread in the div and not the button tag.