### PR TITLE
Fix Wrong Anchor Link

### DIFF
--- a/documentation/react/guide/vite.mdx
+++ b/documentation/react/guide/vite.mdx
@@ -25,7 +25,7 @@ Learn how to setup and install @material-tailwind/react with Vite (React).
 <br />
 <br />
 
-First you need to create a new project using vite, for more details check the <a target="_blank" className="font-medium hover:text-blue-500 transition-colors" href="https://remix.run/docs/en/v1?ref=material-tailwind">Vite Official Documentation</a>
+First you need to create a new project using vite, for more details check the <a target="_blank" className="font-medium hover:text-blue-500 transition-colors" href="https://vitejs.dev/guide/">Vite Official Documentation</a>
 
 ```bash
 npm create vite@latest


### PR DESCRIPTION
The previous vite installation guide link was pointing to [https://remix.run/docs/en/1.19.3], which was incorrect, and I have replaced it with the correct link, [https://vitejs.dev/guide/]. 
Thank you!