### PR TITLE
fix: speed-dial-route fix

### DIFF
--- a/widgets/sections/components.tsx
+++ b/widgets/sections/components.tsx
@@ -140,7 +140,7 @@ const DATA = [
   },
   {
     title: "Speed Dial",
-    route: "speeddial",
+    route: "speed-dial",
     img: "https://docs.material-tailwind.com/image/components/speeddial-thumbnail.jpg",
   },
   {


### PR DESCRIPTION
### Update route from "speeddial" to "speed-dial"

In the file widgets/sections/components.tsx, the route for the speed dial component has been updated from "speeddial" to "speed-dial" to resolve a 404 error.

### Motivation 
issue #505