### PR TITLE
Fix: Input placeholder overlap with label on standard and  outlined variants

### DIFF
--- a/docs-content/html/input/input-variants.tsx
+++ b/docs-content/html/input/input-variants.tsx
@@ -12,8 +12,8 @@ export function InputVariants() {
       </div>
       <div className="relative h-11 w-full min-w-[200px]">
         <input
-          className="peer h-full w-full border-b border-blue-gray-200 bg-transparent pt-4 pb-1.5 font-sans text-sm font-normal text-blue-gray-700 outline outline-0 transition-all placeholder-shown:border-blue-gray-200 focus:border-gray-500 focus:outline-0 disabled:border-0 disabled:bg-blue-gray-50"
-          placeholder=" "
+          placeholder="Standard"
+          className="peer h-full w-full border-b border-blue-gray-200 bg-transparent pt-4 pb-1.5 font-sans text-sm font-normal text-blue-gray-700 outline outline-0 transition-all placeholder:opacity-0 placeholder-shown:border-blue-gray-200 focus:border-gray-500 focus:outline-0 focus:placeholder:opacity-100 disabled:border-0 disabled:bg-blue-gray-50"
         />
         <label className="after:content[''] pointer-events-none absolute left-0  -top-1.5 flex h-full w-full select-none !overflow-visible truncate text-[11px] font-normal leading-tight text-gray-500 transition-all after:absolute after:-bottom-1.5 after:block after:w-full after:scale-x-0 after:border-b-2 after:border-gray-500 after:transition-transform after:duration-300 peer-placeholder-shown:text-sm peer-placeholder-shown:leading-[4.25] peer-placeholder-shown:text-blue-gray-500 peer-focus:text-[11px] peer-focus:leading-tight peer-focus:text-gray-900 peer-focus:after:scale-x-100 peer-focus:after:border-gray-900 peer-disabled:text-transparent peer-disabled:peer-placeholder-shown:text-blue-gray-500">
           Standard
@@ -21,8 +21,8 @@ export function InputVariants() {
       </div>
       <div className="relative h-10 w-full min-w-[200px]">
         <input
-          className="peer h-full w-full rounded-[7px] border border-blue-gray-200 border-t-transparent bg-transparent px-3 py-2.5 font-sans text-sm font-normal text-blue-gray-700 outline outline-0 transition-all placeholder-shown:border placeholder-shown:border-blue-gray-200 placeholder-shown:border-t-blue-gray-200 focus:border-2 focus:border-gray-900 focus:border-t-transparent focus:outline-0 disabled:border-0 disabled:bg-blue-gray-50"
-          placeholder=" "
+          placeholder="Outlined"
+          className="peer h-full w-full rounded-[7px] border border-blue-gray-200 border-t-transparent bg-transparent px-3 py-2.5 font-sans text-sm font-normal text-blue-gray-700 outline outline-0 transition-all placeholder:opacity-0 placeholder-shown:border placeholder-shown:border-blue-gray-200 placeholder-shown:border-t-blue-gray-200 focus:border-2 focus:border-gray-900 focus:border-t-transparent focus:outline-0 focus:placeholder:opacity-100 disabled:border-0 disabled:bg-blue-gray-50"
         />
         <label className="before:content[' '] after:content[' '] pointer-events-none absolute left-0 -top-1.5 flex h-full w-full select-none !overflow-visible truncate text-[11px] font-normal leading-tight text-gray-500 transition-all before:pointer-events-none before:mt-[6.5px] before:mr-1 before:box-border before:block before:h-1.5 before:w-2.5 before:rounded-tl-md before:border-t before:border-l before:border-blue-gray-200 before:transition-all after:pointer-events-none after:mt-[6.5px] after:ml-1 after:box-border after:block after:h-1.5 after:w-2.5 after:flex-grow after:rounded-tr-md after:border-t after:border-r after:border-blue-gray-200 after:transition-all peer-placeholder-shown:text-sm peer-placeholder-shown:leading-[3.75] peer-placeholder-shown:text-blue-gray-500 peer-placeholder-shown:before:border-transparent peer-placeholder-shown:after:border-transparent peer-focus:text-[11px] peer-focus:leading-tight peer-focus:text-gray-900 peer-focus:before:border-t-2 peer-focus:before:border-l-2 peer-focus:before:!border-gray-900 peer-focus:after:border-t-2 peer-focus:after:border-r-2 peer-focus:after:!border-gray-900 peer-disabled:text-transparent peer-disabled:before:border-transparent peer-disabled:after:border-transparent peer-disabled:peer-placeholder-shown:text-blue-gray-500">
           Outlined

--- a/docs-content/react/input/input-variants.tsx
+++ b/docs-content/react/input/input-variants.tsx
@@ -4,8 +4,8 @@ export function InputVariants() {
   return (
     <div className="flex w-72 flex-col gap-6">
       <Input variant="static" label="Static" placeholder="Static" />
-      <Input variant="standard" label="Standard" />
-      <Input variant="outlined" label="Outlined" />
+      <Input variant="standard" label="Standard" placeholder="Standard" />
+      <Input variant="outlined" label="Outlined" placeholder="Outlined" />
     </div>
   );
 }

--- a/documentation/html/input.mdx
+++ b/documentation/html/input.mdx
@@ -70,18 +70,16 @@ See below our input component examples. It comes in different styles and colors,
     </label>
   </div>
   <div class="relative h-11 w-full min-w-[200px]">
-    <input
-      class="peer h-full w-full border-b border-blue-gray-200 bg-transparent pt-4 pb-1.5 font-sans text-sm font-normal text-blue-gray-700 outline outline-0 transition-all placeholder-shown:border-blue-gray-200 focus:border-gray-500 focus:outline-0 disabled:border-0 disabled:bg-blue-gray-50"
-      placeholder=" " />
+    <input placeholder="Standard"
+      class="peer h-full w-full border-b border-blue-gray-200 bg-transparent pt-4 pb-1.5 font-sans text-sm font-normal text-blue-gray-700 outline outline-0 transition-all placeholder-shown:border-blue-gray-200 focus:border-gray-500 focus:outline-0 disabled:border-0 disabled:bg-blue-gray-50 placeholder:opacity-0 focus:placeholder:opacity-100" />
     <label
       class="after:content[''] pointer-events-none absolute left-0  -top-1.5 flex h-full w-full select-none !overflow-visible truncate text-[11px] font-normal leading-tight text-gray-500 transition-all after:absolute after:-bottom-1.5 after:block after:w-full after:scale-x-0 after:border-b-2 after:border-gray-500 after:transition-transform after:duration-300 peer-placeholder-shown:text-sm peer-placeholder-shown:leading-[4.25] peer-placeholder-shown:text-blue-gray-500 peer-focus:text-[11px] peer-focus:leading-tight peer-focus:text-gray-900 peer-focus:after:scale-x-100 peer-focus:after:border-gray-900 peer-disabled:text-transparent peer-disabled:peer-placeholder-shown:text-blue-gray-500">
       Standard
     </label>
   </div>
   <div class="relative h-10 w-full min-w-[200px]">
-    <input
-      class="peer h-full w-full rounded-[7px] border border-blue-gray-200 border-t-transparent bg-transparent px-3 py-2.5 font-sans text-sm font-normal text-blue-gray-700 outline outline-0 transition-all placeholder-shown:border placeholder-shown:border-blue-gray-200 placeholder-shown:border-t-blue-gray-200 focus:border-2 focus:border-gray-900 focus:border-t-transparent focus:outline-0 disabled:border-0 disabled:bg-blue-gray-50"
-      placeholder=" " />
+    <input placeholder="Outlined" 
+      class="peer h-full w-full rounded-[7px] border border-blue-gray-200 border-t-transparent bg-transparent px-3 py-2.5 font-sans text-sm font-normal text-blue-gray-700 outline outline-0 transition-all placeholder-shown:border placeholder-shown:border-blue-gray-200 placeholder-shown:border-t-blue-gray-200 focus:border-2 focus:border-gray-900 focus:border-t-transparent focus:outline-0 disabled:border-0 disabled:bg-blue-gray-50 placeholder:opacity-0 focus:placeholder:opacity-100" />
     <label
       class="before:content[' '] after:content[' '] pointer-events-none absolute left-0 -top-1.5 flex h-full w-full select-none !overflow-visible truncate text-[11px] font-normal leading-tight text-gray-500 transition-all before:pointer-events-none before:mt-[6.5px] before:mr-1 before:box-border before:block before:h-1.5 before:w-2.5 before:rounded-tl-md before:border-t before:border-l before:border-blue-gray-200 before:transition-all after:pointer-events-none after:mt-[6.5px] after:ml-1 after:box-border after:block after:h-1.5 after:w-2.5 after:flex-grow after:rounded-tr-md after:border-t after:border-r after:border-blue-gray-200 after:transition-all peer-placeholder-shown:text-sm peer-placeholder-shown:leading-[3.75] peer-placeholder-shown:text-blue-gray-500 peer-placeholder-shown:before:border-transparent peer-placeholder-shown:after:border-transparent peer-focus:text-[11px] peer-focus:leading-tight peer-focus:text-gray-900 peer-focus:before:border-t-2 peer-focus:before:border-l-2 peer-focus:before:!border-gray-900 peer-focus:after:border-t-2 peer-focus:after:border-r-2 peer-focus:after:!border-gray-900 peer-disabled:text-transparent peer-disabled:before:border-transparent peer-disabled:after:border-transparent peer-disabled:peer-placeholder-shown:text-blue-gray-500">
       Outlined

--- a/documentation/react/input.mdx
+++ b/documentation/react/input.mdx
@@ -74,8 +74,8 @@ export function InputVariants() {
   return (
     <div className="flex w-72 flex-col gap-6">
       <Input variant="static" label="Static" placeholder="Static" />
-      <Input variant="standard" label="Standard" />
-      <Input variant="outlined" label="Outlined" />
+      <Input variant="standard" label="Standard" placeholder="Standard"/>
+      <Input variant="outlined" label="Outlined" placeholder="Outlined"/>
     </div>
   );
 }

--- a/packages/material-tailwind-react/src/theme/components/input/inputOutlined/index.ts
+++ b/packages/material-tailwind-react/src/theme/components/input/inputOutlined/index.ts
@@ -12,6 +12,7 @@ const inputOutlined = {
         borderWidth: "border focus:border-2",
         borderColor: "border-t-transparent focus:border-t-transparent",
       },
+      placeholder: "placeholder:opacity-0 focus:placeholder:opacity-100",
     },
     inputWithIcon: {
       pr: "!pr-9",

--- a/packages/material-tailwind-react/src/theme/components/input/inputStandard/index.ts
+++ b/packages/material-tailwind-react/src/theme/components/input/inputStandard/index.ts
@@ -7,6 +7,7 @@ const inputStandard = {
     input: {
       borderWidth: "border-b",
       borderColor: "placeholder-shown:border-blue-gray-200",
+      placeholder: "placeholder:opacity-0 focus:placeholder:opacity-100",
     },
     inputWithIcon: {
       pr: "!pr-7",


### PR DESCRIPTION
Before : 

https://github.com/creativetimofficial/material-tailwind/assets/36214726/a7e10081-fb92-4f28-8d5e-e889a4dac2f2



After: 

https://github.com/creativetimofficial/material-tailwind/assets/36214726/fa871245-df38-4377-8a3a-6a923d81f863

