### PR TITLE
Updating the README.md to fix the corresponding component names under @material-tailwind/html

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,9 +541,9 @@ Visit <a href="https://www.material-tailwind.com/docs/html/installation">https:/
     </td>
   </tr>
   <tr>
-    <td width="33.3333%">Progress Bar</td>
     <td width="33.3333%">Radio Button</td>
     <td width="33.3333%">Select</td>
+    <td width="33.3333%">Progress Bar</td>
   </tr>
   <tr>
     <td width="33.3333%" style="padding: 0;">
@@ -563,9 +563,9 @@ Visit <a href="https://www.material-tailwind.com/docs/html/installation">https:/
     </td>
   </tr>
   <tr>
-    <td width="33.3333%">Switch</td>
     <td width="33.3333%">Tabs</td>
     <td width="33.3333%">Textarea</td>
+    <td width="33.3333%">Switch</td>
   </tr>
   <tr>
     <td width="33.3333%" style="padding: 0;">
@@ -585,8 +585,8 @@ Visit <a href="https://www.material-tailwind.com/docs/html/installation">https:/
     </td>
   </tr>
   <tr>
-  <td width="33.3333%">Tooltip</td>
-    <td width="33.3333%">Typography</td>
+  <td width="33.3333%">Typography</td>
+    <td width="33.3333%">Tooltip</td>
   </tr>
   <tr>
     <td width="33.3333%" style="padding: 0;">


### PR DESCRIPTION
Just a simple update to fix the corresponding component names under @material-tailwind/html in the README.md