### PR TITLE
Fix duplicate font family values in merged configuration

### DIFF
--- a/packages/material-tailwind-html/utils/withMT.js
+++ b/packages/material-tailwind-html/utils/withMT.js
@@ -35,8 +35,10 @@ function withMT(tailwindConfig) {
     themeFont.serif = serif || themeFont.serif;
     themeFont.body = body || themeFont.body;
   }
-
-  return merge(materialTailwindConfig, { ...tailwindConfig });
+  
+  const mergedConfig = merge(materialTailwindConfig, { ...tailwindConfig });
+  mergedConfig.theme.fontFamily = themeFont;
+  return mergedConfig;
 }
 
 module.exports = withMT;

--- a/packages/material-tailwind-react/src/utils/withMT.js
+++ b/packages/material-tailwind-react/src/utils/withMT.js
@@ -38,8 +38,9 @@ function withMT(tailwindConfig) {
     themeFont.serif = serif || themeFont.serif;
     themeFont.body = body || themeFont.body;
   }
-
-  return merge(materialTailwindConfig, { ...tailwindConfig });
+  const mergedConfig = merge(materialTailwindConfig, { ...tailwindConfig });
+  mergedConfig.theme.fontFamily = themeFont;
+  return mergedConfig;
 }
 
 module.exports = withMT;


### PR DESCRIPTION
### Fix duplicate font family values in merged configuration


This commit addresses an issue where duplicate font family values were being introduced into the merged configuration when merging with the Tailwind CSS config. Specifically, when the `fontFamily` property was set in the Tailwind CSS config with the value `sans: ["Poppins", "monospace"]`, and then merged using the `withMT` function, duplicate entries such as `["Poppins", "Poppins","monospace","monospace"]` were observed.

To resolve this issue, I updated the logic in the `withMT` function to properly merge font family values while avoiding duplicates.
