### PR TITLE
feat: Improve ThemeProvider rendering performance

### DIFF
--- a/packages/material-tailwind-react/src/context/theme.js
+++ b/packages/material-tailwind-react/src/context/theme.js
@@ -9,7 +9,7 @@ const MaterialTailwindTheme = createContext(theme);
 MaterialTailwindTheme.displayName = "MaterialTailwindThemeProvider";
 
 function ThemeProvider({ value = theme, children }) {
-  const mergedValue = merge(theme, value, { arrayMerge: combineMerge });
+  const mergedValue = React.useMemo(() => merge(theme, value, { arrayMerge: combineMerge }), [value]);
 
   return (
     <MaterialTailwindTheme.Provider value={mergedValue}>{children}</MaterialTailwindTheme.Provider>


### PR DESCRIPTION
Little performance improvement

Not an objective comparison of performance:
![Render time without memoization (second render)](https://github.com/creativetimofficial/material-tailwind/assets/44623016/a6e41582-e9ad-4c67-8a28-7d9f340a8b56)

![Render time with memoization (second render)](https://github.com/creativetimofficial/material-tailwind/assets/44623016/19fdae77-8e5e-4141-b246-a6540bf5b5f7)