### PR TITLE
feat: Improve ThemeProvider rendering performance

### DIFF
--- a/packages/material-tailwind-react/src/context/theme.js
+++ b/packages/material-tailwind-react/src/context/theme.js
@@ -9,7 +9,7 @@ const MaterialTailwindTheme = createContext(theme);
 MaterialTailwindTheme.displayName = "MaterialTailwindThemeProvider";
 
 function ThemeProvider({ value = theme, children }) {
-  const mergedValue = merge(theme, value, { arrayMerge: combineMerge });
+  const mergedValue = React.useMemo(() => merge(theme, value, { arrayMerge: combineMerge }), [value]);
 
   return (
     <MaterialTailwindTheme.Provider value={mergedValue}>{children}</MaterialTailwindTheme.Provider>


### PR DESCRIPTION
Little performance improvement

Not an objective comparison of performance:

Render time without memoization (second render)
![](https://github.com/creativetimofficial/material-tailwind/assets/44623016/be46ce53-452f-4e11-a02a-1cb9eecdd2d4)

Render time with memoization (second render)
![](https://github.com/creativetimofficial/material-tailwind/assets/44623016/07a89d2d-4927-4c7b-93ec-6cadc6e91cc6)
