### PR TITLE
Fix color: "gary" -> "gray"

### DIFF
--- a/documentation/react/timeline.mdx
+++ b/documentation/react/timeline.mdx
@@ -57,7 +57,7 @@ export function DefaultTimeline() {
             </Typography>
           </TimelineHeader>
           <TimelineBody className="pb-8">
-            <Typography variant="small" color="gary" className="font-normal text-gray-600">
+            <Typography variant="small" color="gray" className="font-normal text-gray-600">
               The key to more success is to have a lot of pillows. Put it this way, it took me
               twenty five years to get these plants, twenty five years of blood sweat and tears, and
               I&apos;m never giving up, I&apos;m just getting started. I&apos;m up to something. Fan
@@ -74,7 +74,7 @@ export function DefaultTimeline() {
             </Typography>
           </TimelineHeader>
           <TimelineBody className="pb-8">
-            <Typography variant="small" color="gary" className="font-normal text-gray-600">
+            <Typography variant="small" color="gray" className="font-normal text-gray-600">
               The key to more success is to have a lot of pillows. Put it this way, it took me
               twenty five years to get these plants, twenty five years of blood sweat and tears, and
               I&apos;m never giving up, I&apos;m just getting started. I&apos;m up to something. Fan
@@ -90,7 +90,7 @@ export function DefaultTimeline() {
             </Typography>
           </TimelineHeader>
           <TimelineBody>
-            <Typography variant="small" color="gary" className="font-normal text-gray-600">
+            <Typography variant="small" color="gray" className="font-normal text-gray-600">
               The key to more success is to have a lot of pillows. Put it this way, it took me
               twenty five years to get these plants, twenty five years of blood sweat and tears, and
               I&apos;m never giving up, I&apos;m just getting started. I&apos;m up to something. Fan
@@ -141,7 +141,7 @@ export function TimelineWithIcon() {
             </Typography>
           </TimelineHeader>
           <TimelineBody className="pb-8">
-            <Typography color="gary" className="font-normal text-gray-600">
+            <Typography color="gray" className="font-normal text-gray-600">
               The key to more success is to have a lot of pillows. Put it this way, it took me
               twenty five years to get these plants, twenty five years of blood sweat and tears, and
               I&apos;m never giving up, I&apos;m just getting started. I&apos;m up to something. Fan
@@ -160,7 +160,7 @@ export function TimelineWithIcon() {
             </Typography>
           </TimelineHeader>
           <TimelineBody className="pb-8">
-            <Typography color="gary" className="font-normal text-gray-600">
+            <Typography color="gray" className="font-normal text-gray-600">
               The key to more success is to have a lot of pillows. Put it this way, it took me
               twenty five years to get these plants, twenty five years of blood sweat and tears, and
               I&apos;m never giving up, I&apos;m just getting started. I&apos;m up to something. Fan
@@ -178,7 +178,7 @@ export function TimelineWithIcon() {
             </Typography>
           </TimelineHeader>
           <TimelineBody>
-            <Typography color="gary" className="font-normal text-gray-600">
+            <Typography color="gray" className="font-normal text-gray-600">
               The key to more success is to have a lot of pillows. Put it this way, it took me
               twenty five years to get these plants, twenty five years of blood sweat and tears, and
               I&apos;m never giving up, I&apos;m just getting started. I&apos;m up to something. Fan
@@ -229,7 +229,7 @@ export function TimelineWithAvatar() {
             </Typography>
           </TimelineHeader>
           <TimelineBody className="pb-8">
-            <Typography color="gary" className="font-normal text-gray-600">
+            <Typography color="gray" className="font-normal text-gray-600">
               The key to more success is to have a lot of pillows. Put it this way, it took me
               twenty five years to get these plants, twenty five years of blood sweat and tears, and
               I&apos;m never giving up, I&apos;m just getting started. I&apos;m up to something. Fan
@@ -248,7 +248,7 @@ export function TimelineWithAvatar() {
             </Typography>
           </TimelineHeader>
           <TimelineBody className="pb-8">
-            <Typography color="gary" className="font-normal text-gray-600">
+            <Typography color="gray" className="font-normal text-gray-600">
               The key to more success is to have a lot of pillows. Put it this way, it took me
               twenty five years to get these plants, twenty five years of blood sweat and tears, and
               I&apos;m never giving up, I&apos;m just getting started. I&apos;m up to something. Fan
@@ -266,7 +266,7 @@ export function TimelineWithAvatar() {
             </Typography>
           </TimelineHeader>
           <TimelineBody>
-            <Typography color="gary" className="font-normal text-gray-600">
+            <Typography color="gray" className="font-normal text-gray-600">
               The key to more success is to have a lot of pillows. Put it this way, it took me
               twenty five years to get these plants, twenty five years of blood sweat and tears, and
               I&apos;m never giving up, I&apos;m just getting started. I&apos;m up to something. Fan


### PR DESCRIPTION
There is an error in the website, where a color of a Typography component is being indicated as "gary", which causes an error in te terminal. This PR solves this problem, as the color was updated to "gray".

![Captura de ecrã 2024-07-03 161914](https://github.com/creativetimofficial/material-tailwind/assets/81450390/bafa13d6-8f0c-4cc1-b5db-5306b187f93f)
.