### PR TITLE
docs: remove gary from timeline and let tailwind color text

### DIFF
--- a/documentation/react/timeline.mdx
+++ b/documentation/react/timeline.mdx
@@ -58,7 +58,7 @@ export function DefaultTimeline() {
             </Typography>
           </TimelineHeader>
           <TimelineBody className="pb-8">
-            <Typography variant="small" color="gary" className="font-normal text-gray-600">
+            <Typography variant="small" className="font-normal text-gray-600">
               The key to more success is to have a lot of pillows. Put it this way, it took me
               twenty five years to get these plants, twenty five years of blood sweat and tears, and
               I&apos;m never giving up, I&apos;m just getting started. I&apos;m up to something. Fan
@@ -75,7 +75,7 @@ export function DefaultTimeline() {
             </Typography>
           </TimelineHeader>
           <TimelineBody className="pb-8">
-            <Typography variant="small" color="gary" className="font-normal text-gray-600">
+            <Typography variant="small" className="font-normal text-gray-600">
               The key to more success is to have a lot of pillows. Put it this way, it took me
               twenty five years to get these plants, twenty five years of blood sweat and tears, and
               I&apos;m never giving up, I&apos;m just getting started. I&apos;m up to something. Fan
@@ -91,7 +91,7 @@ export function DefaultTimeline() {
             </Typography>
           </TimelineHeader>
           <TimelineBody>
-            <Typography variant="small" color="gary" className="font-normal text-gray-600">
+            <Typography variant="small" className="font-normal text-gray-600">
               The key to more success is to have a lot of pillows. Put it this way, it took me
               twenty five years to get these plants, twenty five years of blood sweat and tears, and
               I&apos;m never giving up, I&apos;m just getting started. I&apos;m up to something. Fan
@@ -142,7 +142,7 @@ export function TimelineWithIcon() {
             </Typography>
           </TimelineHeader>
           <TimelineBody className="pb-8">
-            <Typography color="gary" className="font-normal text-gray-600">
+            <Typography className="font-normal text-gray-600">
               The key to more success is to have a lot of pillows. Put it this way, it took me
               twenty five years to get these plants, twenty five years of blood sweat and tears, and
               I&apos;m never giving up, I&apos;m just getting started. I&apos;m up to something. Fan
@@ -161,7 +161,7 @@ export function TimelineWithIcon() {
             </Typography>
           </TimelineHeader>
           <TimelineBody className="pb-8">
-            <Typography color="gary" className="font-normal text-gray-600">
+            <Typography className="font-normal text-gray-600">
               The key to more success is to have a lot of pillows. Put it this way, it took me
               twenty five years to get these plants, twenty five years of blood sweat and tears, and
               I&apos;m never giving up, I&apos;m just getting started. I&apos;m up to something. Fan
@@ -179,7 +179,7 @@ export function TimelineWithIcon() {
             </Typography>
           </TimelineHeader>
           <TimelineBody>
-            <Typography color="gary" className="font-normal text-gray-600">
+            <Typography className="font-normal text-gray-600">
               The key to more success is to have a lot of pillows. Put it this way, it took me
               twenty five years to get these plants, twenty five years of blood sweat and tears, and
               I&apos;m never giving up, I&apos;m just getting started. I&apos;m up to something. Fan
@@ -230,7 +230,7 @@ export function TimelineWithAvatar() {
             </Typography>
           </TimelineHeader>
           <TimelineBody className="pb-8">
-            <Typography color="gary" className="font-normal text-gray-600">
+            <Typography className="font-normal text-gray-600">
               The key to more success is to have a lot of pillows. Put it this way, it took me
               twenty five years to get these plants, twenty five years of blood sweat and tears, and
               I&apos;m never giving up, I&apos;m just getting started. I&apos;m up to something. Fan
@@ -249,7 +249,7 @@ export function TimelineWithAvatar() {
             </Typography>
           </TimelineHeader>
           <TimelineBody className="pb-8">
-            <Typography color="gary" className="font-normal text-gray-600">
+            <Typography className="font-normal text-gray-600">
               The key to more success is to have a lot of pillows. Put it this way, it took me
               twenty five years to get these plants, twenty five years of blood sweat and tears, and
               I&apos;m never giving up, I&apos;m just getting started. I&apos;m up to something. Fan
@@ -267,7 +267,7 @@ export function TimelineWithAvatar() {
             </Typography>
           </TimelineHeader>
           <TimelineBody>
-            <Typography color="gary" className="font-normal text-gray-600">
+            <Typography className="font-normal text-gray-600">
               The key to more success is to have a lot of pillows. Put it this way, it took me
               twenty five years to get these plants, twenty five years of blood sweat and tears, and
               I&apos;m never giving up, I&apos;m just getting started. I&apos;m up to something. Fan


### PR DESCRIPTION
There was another instance of `color="gary"` in the docs. This time in `timeline.mdx`. The components were also colored via the Tailwind class `text-gray-600` which overwrites the `color` property anyway. So to remove redundancy and probably confusion, I just removed that prop altogether.