### PR TITLE
fix: Select component dynamic options updating doesn't work

### DIFF
--- a/packages/material-tailwind-react/src/components/Select/index.tsx
+++ b/packages/material-tailwind-react/src/components/Select/index.tsx
@@ -205,8 +205,14 @@ const Select = React.forwardRef<HTMLDivElement, SelectProps>(
     });
 
     React.useEffect(() => {
+      listContentRef.current = [
+        ...(React.Children.map(children, (child) => {
+          const { props }: any = child;
+          return props?.value;
+        }) ?? []),
+      ]
       setSelectedIndex(Math.max(0, listContentRef.current.indexOf(value) + 1));
-    }, [value]);
+    }, [value, children]);
 
     const floatingRef = refs.floating;
 


### PR DESCRIPTION
This fixes a few of issues such as #675, #513.

If select options are updated dynamically, "listContentRef" must also be refreshed, and this updating has to depend on both value and children. As a result the selectedIndex state can be updated accordingly.
