### PR TITLE
Fixed typos in docs

### DIFF
--- a/documentation/html/dialog.mdx
+++ b/documentation/html/dialog.mdx
@@ -684,9 +684,9 @@ The following data attributes are available for dialog element.
 | Attribute                 | Description                                                                                     | Default                                                                                                       |
 | ------------------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
 | `data-dialog`             | Set the name of the dialog and reference it to the <br /> dialog trigger and backdrop elements. |                                                                                                               |
-| `data-popover-mount`      | Set the classnaes that should be used when the <br /> dialog is visible.                        | <Code>opacity-1</Code><br /><Code>translate-y-0</Code>                                              |
-| `data-popover-unmount`    | Set the classnaes that should be used when the <br /> dialog is hidden.                         | <Code>opacity-0</Code><br /><Code>-translate-y-14</Code><br /><Code>pointer-events-none</Code> |
-| `data-popover-transition` | Set the classnaes that should be used for <br /> transition of the dialog.                      | <Code>transition-all</Code><br /><Code>duration-300</Code>                                          |
+| `data-popover-mount`      | Set the classnames that should be used when the <br /> dialog is visible.                        | <Code>opacity-1</Code><br /><Code>translate-y-0</Code>                                              |
+| `data-popover-unmount`    | Set the classnames that should be used when the <br /> dialog is hidden.                         | <Code>opacity-0</Code><br /><Code>-translate-y-14</Code><br /><Code>pointer-events-none</Code> |
+| `data-popover-transition` | Set the classnames that should be used for <br /> transition of the dialog.                      | <Code>transition-all</Code><br /><Code>duration-300</Code>                                          |
 
 ---
 

--- a/documentation/html/modal.mdx
+++ b/documentation/html/modal.mdx
@@ -705,9 +705,9 @@ The following data attributes are available for modal element.
 | Attribute                 | Description                                                                                     | Default                                                                                                       |
 | ------------------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
 | `data-dialog`             | Set the name of the modal and reference it to the <br /> modal trigger and backdrop elements. |                                                                                                               |
-| `data-popover-mount`      | Set the classnaes that should be used when the <br /> modal is visible.                        | <Code>opacity-1</Code><br /><Code>translate-y-0</Code>                                              |
-| `data-popover-unmount`    | Set the classnaes that should be used when the <br /> modal is hidden.                         | <Code>opacity-0</Code><br /><Code>-translate-y-14</Code><br /><Code>pointer-events-none</Code> |
-| `data-popover-transition` | Set the classnaes that should be used for <br /> transition of the modal.                      | <Code>transition-all</Code><br /><Code>duration-300</Code>                                          |
+| `data-popover-mount`      | Set the classnames that should be used when the <br /> modal is visible.                        | <Code>opacity-1</Code><br /><Code>translate-y-0</Code>                                              |
+| `data-popover-unmount`    | Set the classnames that should be used when the <br /> modal is hidden.                         | <Code>opacity-0</Code><br /><Code>-translate-y-14</Code><br /><Code>pointer-events-none</Code> |
+| `data-popover-transition` | Set the classnames that should be used for <br /> transition of the modal.                      | <Code>transition-all</Code><br /><Code>duration-300</Code>                                          |
 
 ---
 

--- a/documentation/html/popover.mdx
+++ b/documentation/html/popover.mdx
@@ -452,9 +452,9 @@ The following data attributes are available for popover element.
 | `data-popover`            | Set the name of the popover and reference it to the <br /> popover trigger element. |                                                                          |
 | `data-popover-offset`     | Set the offset between the popover and the popover trigger element.                 | 5                                                                        |
 | `data-popover-placement`  | Set the position of the popover relative to it's trigger element.                   | <Code>top</Code>                                                    |
-| `data-popover-mount`      | Set the classnaes that should be used when the <br /> popover is visible.           | <Code>opacity-1</Code>                                              |
-| `data-popover-unmount`    | Set the classnaes that should be used when the <br /> popover is hidden.            | <Code>opacity-0</Code><br /><Code>pointer-events-none</Code>   |
-| `data-popover-transition` | Set the classnaes that should be used for <br /> transition of the popover.         | <Code>transition-opacity</Code><br /><Code>duration-300</Code> |
+| `data-popover-mount`      | Set the classnames that should be used when the <br /> popover is visible.           | <Code>opacity-1</Code>                                              |
+| `data-popover-unmount`    | Set the classnames that should be used when the <br /> popover is hidden.            | <Code>opacity-0</Code><br /><Code>pointer-events-none</Code>   |
+| `data-popover-transition` | Set the classnames that should be used for <br /> transition of the popover.         | <Code>transition-opacity</Code><br /><Code>duration-300</Code> |
 
 ---
 

--- a/documentation/html/tooltip.mdx
+++ b/documentation/html/tooltip.mdx
@@ -215,9 +215,9 @@ The following data attributes are available for tooltip element.
 | `data-tooltip`            | Set the name of the tooltip and reference it to the <br /> tooltip trigger element. |                                                                          |
 | `data-tooltip-offset`     | Set the offset between the tooltip and the tooltip trigger element.                 | 5                                                                        |
 | `data-tooltip-placement`  | Set the position of the tooltip relative to it's trigger element.                   | <Code>top</Code>                                                    |
-| `data-tooltip-mount`      | Set the classnaes that should be used when the <br /> tooltip is visible.           | <Code>opacity-1</Code>                                              |
-| `data-tooltip-unmount`    | Set the classnaes that should be used when the <br /> tooltip is hidden.            | <Code>opacity-0</Code><br /><Code>pointer-events-none</Code>   |
-| `data-tooltip-transition` | Set the classnaes that should be used for <br /> transition of the tooltip.         | <Code>transition-opacity</Code><br /><Code>duration-300</Code> |
+| `data-tooltip-mount`      | Set the classnames that should be used when the <br /> tooltip is visible.           | <Code>opacity-1</Code>                                              |
+| `data-tooltip-unmount`    | Set the classnames that should be used when the <br /> tooltip is hidden.            | <Code>opacity-0</Code><br /><Code>pointer-events-none</Code>   |
+| `data-tooltip-transition` | Set the classnames that should be used for <br /> transition of the tooltip.         | <Code>transition-opacity</Code><br /><Code>duration-300</Code> |
 
 ---
 


### PR DESCRIPTION
`classnaes` -> `classnames`