### PR TITLE
Include Bun as package manager in examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ yarn-error.log*
 package-lock.json
 yarn.lock
 pnpm-lock.yaml
+bun.lockb
+bun.lock

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,10 @@ yarn dev
 #or
 
 npm run dev
+
+#or
+
+bun run dev
 ```
 
 ## Material Tailwind Structure

--- a/documentation/html/guide/angular.mdx
+++ b/documentation/html/guide/angular.mdx
@@ -4,9 +4,10 @@ description: Learn how to use Material Tailwind components with Angular and Tail
 navigation:
   [
     "installation",
-    "npm",
-    "yarn",
-    "pnpm",
+    "NPM",
+    "Yarn",
+    "PNPM",
+    "Bun",
     "tailwindcss-config",
     "ripple-effect",
     "example",
@@ -36,27 +37,23 @@ Then you need to install Tailwind CSS since @material-tailwind/html is working w
 
 ---
 
-<DocsTitle href="npm">
 ## Using NPM
-</DocsTitle>
 
 Install @material-tailwind/html as a dependency using NPM by running the following command:
 
-<span id="npm" className="scroll-mt-48" />
+<span id="NPM" className="scroll-mt-48" />
 
 ```bash
 npm i @material-tailwind/html
 ```
 
 ---
-
-<DocsTitle href="yarn">
+>
 ## Using Yarn
-</DocsTitle>
 
 Install @material-tailwind/html as a dependency using Yarn by running the following command:
 
-<span id="yarn" className="scroll-mt-48" />
+<span id="Yarn" className="scroll-mt-48" />
 
 ```bash
 yarn add @material-tailwind/html
@@ -68,10 +65,22 @@ yarn add @material-tailwind/html
 
 Install @material-tailwind/html as a dependency using PNPM by running the following command:
 
-<span id="pnpm" className="scroll-mt-48" />
+<span id="PNPM" className="scroll-mt-48" />
 
 ```bash
 pnpm i @material-tailwind/html
+```
+
+---
+>
+## Using Bun
+
+Install @material-tailwind/html as a dependency using Bun by running the following command:
+
+<span id="Bun" className="scroll-mt-48" />
+
+```bash
+bun add @material-tailwind/html
 ```
 
 ---

--- a/documentation/html/guide/django.mdx
+++ b/documentation/html/guide/django.mdx
@@ -4,9 +4,10 @@ description: Learn how to use Material Tailwind components with Django and Tailw
 navigation:
   [
     "installation",
-    "npm",
-    "yarn",
-    "pnpm",
+    "NPM",
+    "Yarn",
+    "PNPM",
+    "Bun",
     "tailwindcss-config",
     "ripple-effect",
     "example",
@@ -143,7 +144,7 @@ Create an **index.html** file inside the **templates** folder that will serve as
 ```
 <br />
 
-Then you need to install Tailwind CSS since @material-tailwind/html works with Tailwind CSS classes and you need to have Tailwind CSS installed on your project. 
+Then you need to install Tailwind CSS since @material-tailwind/html works with Tailwind CSS classes and you need to have Tailwind CSS installed on your project.
 ```bash
 npm install -D tailwindcss
 npx tailwindcss init
@@ -151,13 +152,11 @@ npx tailwindcss init
 
 ---
 
-<DocsTitle href="npm">
 ## Using NPM
-</DocsTitle>
 
 Install @material-tailwind/html as a dependency using NPM by running the following command:
 
-<span id="npm" className="scroll-mt-48" />
+<span id="NPM" className="scroll-mt-48" />
 
 ```bash
 npm i @material-tailwind/html
@@ -165,13 +164,11 @@ npm i @material-tailwind/html
 
 ---
 
-<DocsTitle href="yarn">
 ## Using Yarn
-</DocsTitle>
 
 Install @material-tailwind/html as a dependency using Yarn by running the following command:
 
-<span id="yarn" className="scroll-mt-48" />
+<span id="Yarn" className="scroll-mt-48" />
 
 ```bash
 yarn add @material-tailwind/html
@@ -183,10 +180,22 @@ yarn add @material-tailwind/html
 
 Install @material-tailwind/html as a dependency using PNPM by running the following command:
 
-<span id="pnpm" className="scroll-mt-48" />
+<span id="PNPM" className="scroll-mt-48" />
 
 ```bash
 pnpm i @material-tailwind/html
+```
+
+---
+
+## Using Bun
+
+Install @material-tailwind/html as a dependency using Bun by running the following command:
+
+<span id="Bun" className="scroll-mt-48" />
+
+```bash
+bun add @material-tailwind/html
 ```
 
 ---

--- a/documentation/html/guide/flask.mdx
+++ b/documentation/html/guide/flask.mdx
@@ -4,9 +4,10 @@ description: Learn how to use Material Tailwind components with Flask and Tailwi
 navigation:
   [
     "installation",
-    "npm",
-    "yarn",
-    "pnpm",
+    "NPM",
+    "Yarn",
+    "PNPM",
+    "Bun",
     "tailwindcss-config",
     "ripple-effect",
     "example",
@@ -24,7 +25,7 @@ Learn how to setup and install @material-tailwind/html with Flask.
 <br />
 <br />
 
-First you need to create a new project using Flask, for more details check the <a target="_blank" className="font-medium hover:text-blue-500 transition-colors" href="https://flask.palletsprojects.com/en/2.1.x/installation/?ref=material-tailwind">Flask Official Documentation</a>. 
+First you need to create a new project using Flask, for more details check the <a target="_blank" className="font-medium hover:text-blue-500 transition-colors" href="https://flask.palletsprojects.com/en/2.1.x/installation/?ref=material-tailwind">Flask Official Documentation</a>.
 Then, in the root of your project folder create a new file called **app.py** with the following content:
 
 ```js
@@ -125,13 +126,11 @@ This will generate a new **output.css** file inside the `/static/dist/css/` fold
 
 ---
 
-<DocsTitle href="npm">
 ## Using NPM
-</DocsTitle>
 
 Install @material-tailwind/html as a dependency using NPM by running the following command:
 
-<span id="npm" className="scroll-mt-48" />
+<span id="NPM" className="scroll-mt-48" />
 
 ```bash
 npm i @material-tailwind/html
@@ -139,13 +138,11 @@ npm i @material-tailwind/html
 
 ---
 
-<DocsTitle href="yarn">
 ## Using Yarn
-</DocsTitle>
 
 Install @material-tailwind/html as a dependency using Yarn by running the following command:
 
-<span id="yarn" className="scroll-mt-48" />
+<span id="Yarn" className="scroll-mt-48" />
 
 ```bash
 yarn add @material-tailwind/html
@@ -157,10 +154,22 @@ yarn add @material-tailwind/html
 
 Install @material-tailwind/html as a dependency using PNPM by running the following command:
 
-<span id="pnpm" className="scroll-mt-48" />
+<span id="PNPM" className="scroll-mt-48" />
 
 ```bash
 pnpm i @material-tailwind/html
+```
+
+---
+
+## Using Bun
+
+Install @material-tailwind/html as a dependency using Bun by running the following command:
+
+<span id="Bun" className="scroll-mt-48" />
+
+```bash
+bun add @material-tailwind/html
 ```
 
 ---

--- a/documentation/html/guide/gatsby.mdx
+++ b/documentation/html/guide/gatsby.mdx
@@ -4,9 +4,10 @@ description: Learn how to use Material Tailwind components with Gatsby and Tailw
 navigation:
   [
     "installation",
-    "npm",
-    "yarn",
-    "pnpm",
+    "NPM",
+    "Yarn",
+    "PNPM",
+    "Bun",
     "tailwindcss-config",
     "ripple-effect",
     "example",
@@ -36,13 +37,11 @@ Then you need to install Tailwind CSS since @material-tailwind/html is working w
 
 ---
 
-<DocsTitle href="npm">
 ## Using NPM
-</DocsTitle>
 
 Install @material-tailwind/html as a dependency using NPM by running the following command:
 
-<span id="npm" className="scroll-mt-48" />
+<span id="NPM" className="scroll-mt-48" />
 
 ```bash
 npm i @material-tailwind/html
@@ -50,13 +49,11 @@ npm i @material-tailwind/html
 
 ---
 
-<DocsTitle href="yarn">
 ## Using Yarn
-</DocsTitle>
 
 Install @material-tailwind/html as a dependency using Yarn by running the following command:
 
-<span id="yarn" className="scroll-mt-48" />
+<span id="Yarn" className="scroll-mt-48" />
 
 ```bash
 yarn add @material-tailwind/html
@@ -68,10 +65,22 @@ yarn add @material-tailwind/html
 
 Install @material-tailwind/html as a dependency using PNPM by running the following command:
 
-<span id="pnpm" className="scroll-mt-48" />
+<span id="PNPM" className="scroll-mt-48" />
 
 ```bash
 pnpm i @material-tailwind/html
+```
+
+---
+
+## Using Bun
+
+Install @material-tailwind/html as a dependency using Bun by running the following command:
+
+<span id="Bun" className="scroll-mt-48" />
+
+```bash
+bun add @material-tailwind/html
 ```
 
 ---

--- a/documentation/html/guide/laravel.mdx
+++ b/documentation/html/guide/laravel.mdx
@@ -4,9 +4,10 @@ description: Learn how to use Material Tailwind components with Laravel and Tail
 navigation:
   [
     "installation",
-    "npm",
-    "yarn",
-    "pnpm",
+    "NPM",
+    "Yarn",
+    "PNPM",
+    "Bun",
     "tailwindcss-config",
     "ripple-effect",
     "example",
@@ -44,7 +45,7 @@ Then you need to create the Tailwind CSS configuration file by running the follo
 
 ```bash
 npx tailwindcss init -p
-``` 
+```
 
 <br />
 
@@ -71,13 +72,11 @@ After setting up Tailwind CSS you need to install @material-tailwind/html as a d
 
 ---
 
-<DocsTitle href="npm">
 ## Using NPM
-</DocsTitle>
 
 Install @material-tailwind/html as a dependency using NPM by running the following command:
 
-<span id="npm" className="scroll-mt-48" />
+<span id="NPM" className="scroll-mt-48" />
 
 ```bash
 npm i @material-tailwind/html
@@ -85,9 +84,7 @@ npm i @material-tailwind/html
 
 ---
 
-<DocsTitle href="yarn">
 ## Using Yarn
-</DocsTitle>
 
 Install @material-tailwind/html as a dependency using Yarn by running the following command:
 
@@ -103,10 +100,22 @@ yarn add @material-tailwind/html
 
 Install @material-tailwind/html as a dependency using PNPM by running the following command:
 
-<span id="pnpm" className="scroll-mt-48" />
+<span id="PNPM" className="scroll-mt-48" />
 
 ```bash
 pnpm i @material-tailwind/html
+```
+
+---
+
+## Using Bun
+
+Install @material-tailwind/html as a dependency using Bun by running the following command:
+
+<span id="Bun" className="scroll-mt-48" />
+
+```bash
+bun add @material-tailwind/html
 ```
 
 ---

--- a/documentation/html/guide/meteor.mdx
+++ b/documentation/html/guide/meteor.mdx
@@ -4,9 +4,10 @@ description: Learn how to use Material Tailwind components with Meteor and Tailw
 navigation:
   [
     "installation",
-    "npm",
-    "yarn",
-    "pnpm",
+    "NPM",
+    "Yarn",
+    "PNPM",
+    "Bun",
     "tailwindcss-config",
     "ripple-effect",
     "example",
@@ -36,13 +37,11 @@ Then you need to install Tailwind CSS since @material-tailwind/html is working w
 
 ---
 
-<DocsTitle href="npm">
 ## Using NPM
-</DocsTitle>
 
 Install @material-tailwind/html as a dependency using NPM by running the following command:
 
-<span id="npm" className="scroll-mt-48" />
+<span id="NPM" className="scroll-mt-48" />
 
 ```bash
 npm i @material-tailwind/html
@@ -50,13 +49,11 @@ npm i @material-tailwind/html
 
 ---
 
-<DocsTitle href="yarn">
 ## Using Yarn
-</DocsTitle>
 
 Install @material-tailwind/html as a dependency using Yarn by running the following command:
 
-<span id="yarn" className="scroll-mt-48" />
+<span id="Yarn" className="scroll-mt-48" />
 
 ```bash
 yarn add @material-tailwind/html
@@ -68,10 +65,22 @@ yarn add @material-tailwind/html
 
 Install @material-tailwind/html as a dependency using PNPM by running the following command:
 
-<span id="pnpm" className="scroll-mt-48" />
+<span id="PNPM" className="scroll-mt-48" />
 
 ```bash
 pnpm i @material-tailwind/html
+```
+
+---
+
+## Using Bun
+
+Install @material-tailwind/html as a dependency using Bun by running the following command:
+
+<span id="Bun" className="scroll-mt-48" />
+
+```bash
+bun add @material-tailwind/html
 ```
 
 ---

--- a/documentation/html/guide/next.mdx
+++ b/documentation/html/guide/next.mdx
@@ -4,9 +4,10 @@ description: Learn how to use Material Tailwind components with Next.js and Tail
 navigation:
   [
     "installation",
-    "npm",
-    "yarn",
-    "pnpm",
+    "NPM",
+    "Yarn",
+    "PNPM",
+    "Bun",
     "tailwindcss-config",
     "ripple-effect",
     "example",
@@ -32,19 +33,17 @@ npx create-next-app@latest
 
 <br />
 
-@material-tailwind/html is working with Tailwind CSS classes and you need to have Tailwind CSS installed on your project, Next.js provides Tailwind CSS support out of the box, so you don't need to install it manually. 
+@material-tailwind/html is working with Tailwind CSS classes and you need to have Tailwind CSS installed on your project, Next.js provides Tailwind CSS support out of the box, so you don't need to install it manually.
 
 If you want to install Tailwind CSS manually check the <a href="https://tailwindcss.com/docs/guides/nextjs?ref=material-tailwind" target="_blank" className="font-medium hover:text-blue-500 transition-colors">Tailwind CSS Installation</a> for Next.js on Tailwind CSS Documentation
 
 ---
 
-<DocsTitle href="npm">
 ## Using NPM
-</DocsTitle>
 
 Install @material-tailwind/html as a dependency using NPM by running the following command:
 
-<span id="npm" className="scroll-mt-48" />
+<span id="NPM" className="scroll-mt-48" />
 
 ```bash
 npm i @material-tailwind/html
@@ -52,13 +51,11 @@ npm i @material-tailwind/html
 
 ---
 
-<DocsTitle href="yarn">
 ## Using Yarn
-</DocsTitle>
 
 Install @material-tailwind/html as a dependency using Yarn by running the following command:
 
-<span id="yarn" className="scroll-mt-48" />
+<span id="Yarn" className="scroll-mt-48" />
 
 ```bash
 yarn add @material-tailwind/html
@@ -70,10 +67,22 @@ yarn add @material-tailwind/html
 
 Install @material-tailwind/html as a dependency using PNPM by running the following command:
 
-<span id="pnpm" className="scroll-mt-48" />
+<span id="PNPM" className="scroll-mt-48" />
 
 ```bash
 pnpm i @material-tailwind/html
+```
+
+---
+
+## Using Bun
+
+Install @material-tailwind/html as a dependency using Bun by running the following command:
+
+<span id="Bun" className="scroll-mt-48" />
+
+```bash
+bun add @material-tailwind/html
 ```
 
 ---

--- a/documentation/html/guide/nuxt.mdx
+++ b/documentation/html/guide/nuxt.mdx
@@ -4,9 +4,10 @@ description: Learn how to use Material Tailwind components with Nuxt.js and Tail
 navigation:
   [
     "installation",
-    "npm",
-    "yarn",
-    "pnpm",
+    "NPM",
+    "Yarn",
+    "PNPM",
+    "Bun",
     "tailwindcss-config",
     "ripple-effect",
     "example",
@@ -37,13 +38,11 @@ Check <a href="https://tailwindcss.com/docs/guides/nuxtjs?ref=material-tailwind"
 
 ---
 
-<DocsTitle href="npm">
 ## Using NPM
-</DocsTitle>
 
 Install @material-tailwind/html as a dependency using NPM by running the following command:
 
-<span id="npm" className="scroll-mt-48" />
+<span id="NPM" className="scroll-mt-48" />
 
 ```bash
 npm i @material-tailwind/html
@@ -51,13 +50,11 @@ npm i @material-tailwind/html
 
 ---
 
-<DocsTitle href="yarn">
 ## Using Yarn
-</DocsTitle>
 
 Install @material-tailwind/html as a dependency using Yarn by running the following command:
 
-<span id="yarn" className="scroll-mt-48" />
+<span id="Yarn" className="scroll-mt-48" />
 
 ```bash
 yarn add @material-tailwind/html
@@ -69,10 +66,22 @@ yarn add @material-tailwind/html
 
 Install @material-tailwind/html as a dependency using PNPM by running the following command:
 
-<span id="pnpm" className="scroll-mt-48" />
+<span id="PNPM" className="scroll-mt-48" />
 
 ```bash
 pnpm i @material-tailwind/html
+```
+
+---
+
+## Using Bun
+
+Install @material-tailwind/html as a dependency using Bun by running the following command:
+
+<span id="Bun" className="scroll-mt-48" />
+
+```bash
+bun add @material-tailwind/html
 ```
 
 ---

--- a/documentation/html/guide/phoenix.mdx
+++ b/documentation/html/guide/phoenix.mdx
@@ -4,9 +4,10 @@ description: Learn how to use Material Tailwind components with Phoenix and Tail
 navigation:
   [
     "installation",
-    "npm",
-    "yarn",
-    "pnpm",
+    "NPM",
+    "Yarn",
+    "PNPM",
+    "Bun",
     "tailwindcss-config",
     "ripple-effect",
     "example",
@@ -36,13 +37,11 @@ Then you need to install Tailwind CSS since @material-tailwind/html is working w
 
 ---
 
-<DocsTitle href="npm">
 ## Using NPM
-</DocsTitle>
 
 Install @material-tailwind/html as a dependency using NPM by running the following command:
 
-<span id="npm" className="scroll-mt-48" />
+<span id="NPM" className="scroll-mt-48" />
 
 ```bash
 npm i @material-tailwind/html
@@ -50,13 +49,11 @@ npm i @material-tailwind/html
 
 ---
 
-<DocsTitle href="yarn">
 ## Using Yarn
-</DocsTitle>
 
 Install @material-tailwind/html as a dependency using Yarn by running the following command:
 
-<span id="yarn" className="scroll-mt-48" />
+<span id="Yarn" className="scroll-mt-48" />
 
 ```bash
 yarn add @material-tailwind/html
@@ -68,10 +65,22 @@ yarn add @material-tailwind/html
 
 Install @material-tailwind/html as a dependency using PNPM by running the following command:
 
-<span id="pnpm" className="scroll-mt-48" />
+<span id="PNPM" className="scroll-mt-48" />
 
 ```bash
 pnpm i @material-tailwind/html
+```
+
+---
+
+## Using Bun
+
+Install @material-tailwind/html as a dependency using Bun by running the following command:
+
+<span id="Bun" className="scroll-mt-48" />
+
+```bash
+bun add @material-tailwind/html
 ```
 
 ---

--- a/documentation/html/guide/qwik.mdx
+++ b/documentation/html/guide/qwik.mdx
@@ -4,9 +4,10 @@ description: Learn how to use Material Tailwind components with Qwik and Tailwin
 navigation:
   [
     "installation",
-    "npm",
-    "yarn",
-    "pnpm",
+    "NPM",
+    "Yarn",
+    "PNPM",
+    "Bun",
     "tailwindcss-config",
     "ripple-effect",
     "example",
@@ -36,13 +37,11 @@ Then you need to install Tailwind CSS since @material-tailwind/html is working w
 
 ---
 
-<DocsTitle href="npm">
 ## Using NPM
-</DocsTitle>
 
 Install @material-tailwind/html as a dependency using NPM by running the following command:
 
-<span id="npm" className="scroll-mt-48" />
+<span id="NPM" className="scroll-mt-48" />
 
 ```bash
 npm i @material-tailwind/html
@@ -50,13 +49,11 @@ npm i @material-tailwind/html
 
 ---
 
-<DocsTitle href="yarn">
 ## Using Yarn
-</DocsTitle>
 
 Install @material-tailwind/html as a dependency using Yarn by running the following command:
 
-<span id="yarn" className="scroll-mt-48" />
+<span id="Yarn" className="scroll-mt-48" />
 
 ```bash
 yarn add @material-tailwind/html
@@ -68,10 +65,22 @@ yarn add @material-tailwind/html
 
 Install @material-tailwind/html as a dependency using PNPM by running the following command:
 
-<span id="pnpm" className="scroll-mt-48" />
+<span id="PNPM" className="scroll-mt-48" />
 
 ```bash
 pnpm i @material-tailwind/html
+```
+
+---
+
+## Using Bun
+
+Install @material-tailwind/html as a dependency using Bun by running the following command:
+
+<span id="Bun" className="scroll-mt-48" />
+
+```bash
+bun add @material-tailwind/html
 ```
 
 ---

--- a/documentation/html/guide/react-vite.mdx
+++ b/documentation/html/guide/react-vite.mdx
@@ -4,9 +4,10 @@ description: Learn how to use Material Tailwind components with Vite (React) and
 navigation:
   [
     "installation",
-    "npm",
-    "yarn",
-    "pnpm",
+    "NPM",
+    "Yarn",
+    "PNPM",
+    "Bun",
     "tailwindcss-config",
     "ripple-effect",
     "example",
@@ -37,13 +38,11 @@ Check <a href="https://tailwindcss.com/docs/guides/vite?ref=material-tailwind" t
 
 ---
 
-<DocsTitle href="npm">
 ## Using NPM
-</DocsTitle>
 
 Install @material-tailwind/html as a dependency using NPM by running the following command:
 
-<span id="npm" className="scroll-mt-48" />
+<span id="NPM" className="scroll-mt-48" />
 
 ```bash
 npm i @material-tailwind/html
@@ -51,13 +50,11 @@ npm i @material-tailwind/html
 
 ---
 
-<DocsTitle href="yarn">
 ## Using Yarn
-</DocsTitle>
 
 Install @material-tailwind/html as a dependency using Yarn by running the following command:
 
-<span id="yarn" className="scroll-mt-48" />
+<span id="Yarn" className="scroll-mt-48" />
 
 ```bash
 yarn add @material-tailwind/html
@@ -69,10 +66,22 @@ yarn add @material-tailwind/html
 
 Install @material-tailwind/html as a dependency using PNPM by running the following command:
 
-<span id="pnpm" className="scroll-mt-48" />
+<span id="PNPM" className="scroll-mt-48" />
 
 ```bash
 pnpm i @material-tailwind/html
+```
+
+---
+
+## Using Bun
+
+Install @material-tailwind/html as a dependency using Bun by running the following command:
+
+<span id="Bun" className="scroll-mt-48" />
+
+```bash
+bun add @material-tailwind/html
 ```
 
 ---

--- a/documentation/html/guide/remix.mdx
+++ b/documentation/html/guide/remix.mdx
@@ -4,9 +4,10 @@ description: Learn how to use Material Tailwind components with Remix and Tailwi
 navigation:
   [
     "installation",
-    "npm",
-    "yarn",
-    "pnpm",
+    "NPM",
+    "Yarn",
+    "PNPM",
+    "Bun",
     "tailwindcss-config",
     "ripple-effect",
     "example",
@@ -36,13 +37,11 @@ Then you need to install Tailwind CSS since @material-tailwind/html is working w
 
 ---
 
-<DocsTitle href="npm">
 ## Using NPM
-</DocsTitle>
 
 Install @material-tailwind/html as a dependency using NPM by running the following command:
 
-<span id="npm" className="scroll-mt-48" />
+<span id="NPM" className="scroll-mt-48" />
 
 ```bash
 npm i @material-tailwind/html
@@ -50,13 +49,11 @@ npm i @material-tailwind/html
 
 ---
 
-<DocsTitle href="yarn">
 ## Using Yarn
-</DocsTitle>
 
 Install @material-tailwind/html as a dependency using Yarn by running the following command:
 
-<span id="yarn" className="scroll-mt-48" />
+<span id="Yarn" className="scroll-mt-48" />
 
 ```bash
 yarn add @material-tailwind/html
@@ -68,10 +65,22 @@ yarn add @material-tailwind/html
 
 Install @material-tailwind/html as a dependency using PNPM by running the following command:
 
-<span id="pnpm" className="scroll-mt-48" />
+<span id="PNPM" className="scroll-mt-48" />
 
 ```bash
 pnpm i @material-tailwind/html
+```
+
+---
+
+## Using Bun
+
+Install @material-tailwind/html as a dependency using Bun by running the following command:
+
+<span id="Bun" className="scroll-mt-48" />
+
+```bash
+bun add @material-tailwind/html
 ```
 
 ---

--- a/documentation/html/guide/solid.mdx
+++ b/documentation/html/guide/solid.mdx
@@ -4,9 +4,10 @@ description: Learn how to use Material Tailwind components with Solid and Tailwi
 navigation:
   [
     "installation",
-    "npm",
-    "yarn",
-    "pnpm",
+    "NPM",
+    "Yarn",
+    "PNPM",
+    "Bun",
     "tailwindcss-config",
     "ripple-effect",
     "example",
@@ -36,13 +37,11 @@ Then you need to install Tailwind CSS since @material-tailwind/html is working w
 
 ---
 
-<DocsTitle href="npm">
 ## Using NPM
-</DocsTitle>
 
 Install @material-tailwind/html as a dependency using NPM by running the following command:
 
-<span id="npm" className="scroll-mt-48" />
+<span id="NPM" className="scroll-mt-48" />
 
 ```bash
 npm i @material-tailwind/html
@@ -50,13 +49,11 @@ npm i @material-tailwind/html
 
 ---
 
-<DocsTitle href="yarn">
 ## Using Yarn
-</DocsTitle>
 
 Install @material-tailwind/html as a dependency using Yarn by running the following command:
 
-<span id="yarn" className="scroll-mt-48" />
+<span id="Yarn" className="scroll-mt-48" />
 
 ```bash
 yarn add @material-tailwind/html
@@ -68,10 +65,22 @@ yarn add @material-tailwind/html
 
 Install @material-tailwind/html as a dependency using PNPM by running the following command:
 
-<span id="pnpm" className="scroll-mt-48" />
+<span id="PNPM" className="scroll-mt-48" />
 
 ```bash
 pnpm i @material-tailwind/html
+```
+
+---
+
+## Using Bun
+
+Install @material-tailwind/html as a dependency using Bun by running the following command:
+
+<span id="Bun" className="scroll-mt-48" />
+
+```bash
+bun add @material-tailwind/html
 ```
 
 ---

--- a/documentation/html/guide/svelte.mdx
+++ b/documentation/html/guide/svelte.mdx
@@ -4,9 +4,10 @@ description: Learn how to use Material Tailwind components with Svelte and Tailw
 navigation:
   [
     "installation",
-    "npm",
-    "yarn",
-    "pnpm",
+    "NPM",
+    "Yarn",
+    "PNPM",
+    "Bun",
     "tailwindcss-config",
     "ripple-effect",
     "example",
@@ -37,13 +38,11 @@ Check <a href="https://tailwindcss.com/docs/guides/sveltekit?ref=material-tailwi
 
 ---
 
-<DocsTitle href="npm">
 ## Using NPM
-</DocsTitle>
 
 Install @material-tailwind/html as a dependency using NPM by running the following command:
 
-<span id="npm" className="scroll-mt-48" />
+<span id="NPM" className="scroll-mt-48" />
 
 ```bash
 npm i @material-tailwind/html
@@ -51,13 +50,11 @@ npm i @material-tailwind/html
 
 ---
 
-<DocsTitle href="yarn">
 ## Using Yarn
-</DocsTitle>
 
 Install @material-tailwind/html as a dependency using Yarn by running the following command:
 
-<span id="yarn" className="scroll-mt-48" />
+<span id="Yarn" className="scroll-mt-48" />
 
 ```bash
 yarn add @material-tailwind/html
@@ -69,10 +66,22 @@ yarn add @material-tailwind/html
 
 Install @material-tailwind/html as a dependency using PNPM by running the following command:
 
-<span id="pnpm" className="scroll-mt-48" />
+<span id="PNPM" className="scroll-mt-48" />
 
 ```bash
 pnpm i @material-tailwind/html
+```
+
+---
+
+## Using Bun
+
+Install @material-tailwind/html as a dependency using Bun by running the following command:
+
+<span id="Bun" className="scroll-mt-48" />
+
+```bash
+bun add @material-tailwind/html
 ```
 
 ---

--- a/documentation/html/guide/symfony.mdx
+++ b/documentation/html/guide/symfony.mdx
@@ -4,9 +4,10 @@ description: Learn how to use Material Tailwind components with Symfony and Tail
 navigation:
   [
     "installation",
-    "npm",
-    "yarn",
-    "pnpm",
+    "NPM",
+    "Yarn",
+    "PNPM",
+    "Bun",
     "tailwindcss-config",
     "ripple-effect",
     "example",
@@ -42,13 +43,11 @@ Then you need to install Tailwind CSS since @material-tailwind/html is working w
 
 ---
 
-<DocsTitle href="npm">
 ## Using NPM
-</DocsTitle>
 
 Install @material-tailwind/html as a dependency using NPM by running the following command:
 
-<span id="npm" className="scroll-mt-48" />
+<span id="NPM" className="scroll-mt-48" />
 
 ```bash
 npm i @material-tailwind/html
@@ -56,13 +55,11 @@ npm i @material-tailwind/html
 
 ---
 
-<DocsTitle href="yarn">
 ## Using Yarn
-</DocsTitle>
 
 Install @material-tailwind/html as a dependency using Yarn by running the following command:
 
-<span id="yarn" className="scroll-mt-48" />
+<span id="Yarn" className="scroll-mt-48" />
 
 ```bash
 yarn add @material-tailwind/html
@@ -74,10 +71,22 @@ yarn add @material-tailwind/html
 
 Install @material-tailwind/html as a dependency using PNPM by running the following command:
 
-<span id="pnpm" className="scroll-mt-48" />
+<span id="PNPM" className="scroll-mt-48" />
 
 ```bash
 pnpm i @material-tailwind/html
+```
+
+---
+
+## Using Bun
+
+Install @material-tailwind/html as a dependency using Bun by running the following command:
+
+<span id="Bun" className="scroll-mt-48" />
+
+```bash
+bun add @material-tailwind/html
 ```
 
 ---

--- a/documentation/html/guide/vue-vite.mdx
+++ b/documentation/html/guide/vue-vite.mdx
@@ -4,9 +4,10 @@ description: Learn how to use Material Tailwind components with Vite (Vue) and T
 navigation:
   [
     "installation",
-    "npm",
-    "yarn",
-    "pnpm",
+    "NPM",
+    "Yarn",
+    "PNPM",
+    "Bun",
     "tailwindcss-config",
     "ripple-effect",
     "example",
@@ -37,13 +38,11 @@ Check <a href="https://tailwindcss.com/docs/guides/vite?ref=material-tailwind" t
 
 ---
 
-<DocsTitle href="npm">
 ## Using NPM
-</DocsTitle>
 
 Install @material-tailwind/html as a dependency using NPM by running the following command:
 
-<span id="npm" className="scroll-mt-48" />
+<span id="NPM" className="scroll-mt-48" />
 
 ```bash
 npm i @material-tailwind/html
@@ -51,13 +50,11 @@ npm i @material-tailwind/html
 
 ---
 
-<DocsTitle href="yarn">
 ## Using Yarn
-</DocsTitle>
 
 Install @material-tailwind/html as a dependency using Yarn by running the following command:
 
-<span id="yarn" className="scroll-mt-48" />
+<span id="Yarn" className="scroll-mt-48" />
 
 ```bash
 yarn add @material-tailwind/html
@@ -69,10 +66,22 @@ yarn add @material-tailwind/html
 
 Install @material-tailwind/html as a dependency using PNPM by running the following command:
 
-<span id="pnpm" className="scroll-mt-48" />
+<span id="PNPM" className="scroll-mt-48" />
 
 ```bash
 pnpm i @material-tailwind/html
+```
+
+---
+
+## Using Bun
+
+Install @material-tailwind/html as a dependency using Bun by running the following command:
+
+<span id="Bun" className="scroll-mt-48" />
+
+```bash
+yarn add @material-tailwind/html
 ```
 
 ---

--- a/documentation/html/installation.mdx
+++ b/documentation/html/installation.mdx
@@ -5,8 +5,10 @@ navigation:
   [
     "quick-start",
     "installation",
-    "npm",
-    "yarn",
+    "NPM",
+    "Yarn",
+    "PNPM",
+    "Bun",
     "tailwindcss-config",
     "ripple-effect",
     "icons",
@@ -41,7 +43,7 @@ Learn how to use @material-tailwind/html components from this documentation to q
 
 Install @material-tailwind/html as a dependency using NPM by running the following command:
 
-<span id="npm" className="scroll-mt-48" />
+<span id="NPM" className="scroll-mt-48" />
 
 ```bash
 npm i @material-tailwind/html
@@ -53,7 +55,7 @@ npm i @material-tailwind/html
 
 Install @material-tailwind/html as a dependency using Yarn by running the following command:
 
-<span id="yarn" className="scroll-mt-48" />
+<span id="Yarn" className="scroll-mt-48" />
 
 ```bash
 yarn add @material-tailwind/html
@@ -65,10 +67,22 @@ yarn add @material-tailwind/html
 
 Install @material-tailwind/html as a dependency using PNPM by running the following command:
 
-<span id="pnpm" className="scroll-mt-48" />
+<span id="PNPM" className="scroll-mt-48" />
 
 ```bash
 pnpm i @material-tailwind/html
+```
+
+---
+
+## Using Bun
+
+Install @material-tailwind/html as a dependency using Bun by running the following command:
+
+<span id="Bun" className="scroll-mt-48" />
+
+```bash
+bun add @material-tailwind/html
 ```
 
 ---

--- a/documentation/react/guide/astro.mdx
+++ b/documentation/react/guide/astro.mdx
@@ -4,9 +4,10 @@ description: Learn how to use Material Tailwind components with Astro and Tailwi
 navigation:
   [
     "installation",
-    "npm",
-    "yarn",
-    "pnpm",
+    "NPM",
+    "Yarn",
+    "PNPM",
+    "Bun",
     "tailwindcss-config",
     "with-monorepo",
     "theme-provider",
@@ -51,13 +52,11 @@ npx astro add react
 
 ---
 
-<DocsTitle href="npm">
 ## Using NPM
-</DocsTitle>
 
 Install @material-tailwind/react as a dependency using NPM by running the following command:
 
-<span id="npm" className="scroll-mt-48" />
+<span id="NPM" className="scroll-mt-48" />
 
 ```bash
 npm i @material-tailwind/react
@@ -65,13 +64,11 @@ npm i @material-tailwind/react
 
 ---
 
-<DocsTitle href="yarn">
 ## Using Yarn
-</DocsTitle>
 
 Install @material-tailwind/react as a dependency using Yarn by running the following command:
 
-<span id="yarn" className="scroll-mt-48" />
+<span id="Yarn" className="scroll-mt-48" />
 
 ```bash
 yarn add @material-tailwind/react
@@ -79,16 +76,26 @@ yarn add @material-tailwind/react
 
 ---
 
-<DocsTitle href="pnpm">
 ## Using PNPM
-</DocsTitle>
 
 Install @material-tailwind/react as a dependency using PNPM by running the following command:
 
-<span id="pnpm" className="scroll-mt-48" />
+<span id="PNPM" className="scroll-mt-48" />
 
 ```bash
 pnpm i @material-tailwind/react
+```
+
+---
+
+## Using Bun
+
+Install @material-tailwind/react as a dependency using Bun by running the following command:
+
+<span id="Bun" className="scroll-mt-48" />
+
+```bash
+bun add @material-tailwind/react
 ```
 
 ---

--- a/documentation/react/guide/cra.mdx
+++ b/documentation/react/guide/cra.mdx
@@ -4,9 +4,10 @@ description: Learn how to use Material Tailwind components with Create React App
 navigation:
   [
     "installation",
-    "npm",
-    "yarn",
-    "pnpm",
+    "NPM",
+    "Yarn",
+    "PNPM",
+    "Bun",
     "tailwindcss-config",
     "with-monorepo",
     "theme-provider",
@@ -38,13 +39,11 @@ Check <a href="https://tailwindcss.com/docs/guides/create-react-app?ref=material
 
 ---
 
-<DocsTitle href="npm">
 ## Using NPM
-</DocsTitle>
 
 Install @material-tailwind/react as a dependency using NPM by running the following command:
 
-<span id="npm" className="scroll-mt-48" />
+<span id="NPM" className="scroll-mt-48" />
 
 ```bash
 npm i @material-tailwind/react
@@ -52,13 +51,11 @@ npm i @material-tailwind/react
 
 ---
 
-<DocsTitle href="yarn">
 ## Using Yarn
-</DocsTitle>
 
 Install @material-tailwind/react as a dependency using Yarn by running the following command:
 
-<span id="yarn" className="scroll-mt-48" />
+<span id="Yarn" className="scroll-mt-48" />
 
 ```bash
 yarn add @material-tailwind/react
@@ -66,16 +63,26 @@ yarn add @material-tailwind/react
 
 ---
 
-<DocsTitle href="pnpm">
 ## Using PNPM
-</DocsTitle>
 
 Install @material-tailwind/react as a dependency using PNPM by running the following command:
 
-<span id="pnpm" className="scroll-mt-48" />
+<span id="PNPM" className="scroll-mt-48" />
 
 ```bash
 pnpm i @material-tailwind/react
+```
+
+---
+
+## Using Bun
+
+Install @material-tailwind/react as a dependency using Bun by running the following command:
+
+<span id="Bun" className="scroll-mt-48" />
+
+```bash
+bun add @material-tailwind/react
 ```
 
 ---

--- a/documentation/react/guide/gatsby.mdx
+++ b/documentation/react/guide/gatsby.mdx
@@ -4,9 +4,10 @@ description: Learn how to use Material Tailwind components with Gatsby and Tailw
 navigation:
   [
     "installation",
-    "npm",
-    "yarn",
-    "pnpm",
+    "NPM",
+    "Yarn",
+    "PNPM",
+    "Bun",
     "tailwindcss-config",
     "with-monorepo",
     "theme-provider",
@@ -38,13 +39,11 @@ Check <a href="https://tailwindcss.com/docs/guides/gatsby?ref=material-tailwind"
 
 ---
 
-<DocsTitle href="npm">
 ## Using NPM
-</DocsTitle>
 
 Install @material-tailwind/react as a dependency using NPM by running the following command:
 
-<span id="npm" className="scroll-mt-48" />
+<span id="NPM" className="scroll-mt-48" />
 
 ```bash
 npm i @material-tailwind/react
@@ -52,13 +51,11 @@ npm i @material-tailwind/react
 
 ---
 
-<DocsTitle href="yarn">
 ## Using Yarn
-</DocsTitle>
 
 Install @material-tailwind/react as a dependency using Yarn by running the following command:
 
-<span id="yarn" className="scroll-mt-48" />
+<span id="Yarn" className="scroll-mt-48" />
 
 ```bash
 yarn add @material-tailwind/react
@@ -66,16 +63,26 @@ yarn add @material-tailwind/react
 
 ---
 
-<DocsTitle href="pnpm">
 ## Using PNPM
-</DocsTitle>
 
 Install @material-tailwind/react as a dependency using PNPM by running the following command:
 
-<span id="pnpm" className="scroll-mt-48" />
+<span id="PNPM" className="scroll-mt-48" />
 
 ```bash
 pnpm i @material-tailwind/react
+```
+
+---
+
+## Using Bun
+
+Install @material-tailwind/react as a dependency using Bun by running the following command:
+
+<span id="Bun" className="scroll-mt-48" />
+
+```bash
+bun add @material-tailwind/react
 ```
 
 ---

--- a/documentation/react/guide/next.mdx
+++ b/documentation/react/guide/next.mdx
@@ -4,9 +4,10 @@ description: Learn how to use Material Tailwind components with Next.js and Tail
 navigation:
   [
     "installation",
-    "npm",
-    "yarn",
-    "pnpm",
+    "NPM",
+    "Yarn",
+    "PNPM",
+    "Bun",
     "tailwindcss-config",
     "with-server-components",
     "with-monorepo",
@@ -38,13 +39,11 @@ If you have an existing Next.js project and need to install Tailwind CSS manuall
 
 ---
 
-<DocsTitle href="npm">
 ## Using NPM
-</DocsTitle>
 
 Install @material-tailwind/react as a dependency using NPM by running the following command:
 
-<span id="npm" className="scroll-mt-48" />
+<span id="NPM" className="scroll-mt-48" />
 
 ```bash
 npm i @material-tailwind/react
@@ -52,13 +51,11 @@ npm i @material-tailwind/react
 
 ---
 
-<DocsTitle href="yarn">
 ## Using Yarn
-</DocsTitle>
 
 Install @material-tailwind/react as a dependency using Yarn by running the following command:
 
-<span id="yarn" className="scroll-mt-48" />
+<span id="Yarn" className="scroll-mt-48" />
 
 ```bash
 yarn add @material-tailwind/react
@@ -66,16 +63,26 @@ yarn add @material-tailwind/react
 
 ---
 
-<DocsTitle href="pnpm">
 ## Using PNPM
-</DocsTitle>
 
 Install @material-tailwind/react as a dependency using PNPM by running the following command:
 
-<span id="pnpm" className="scroll-mt-48" />
+<span id="PNPM" className="scroll-mt-48" />
 
 ```bash
 pnpm i @material-tailwind/react
+```
+
+---
+
+## Using Bun
+
+Install @material-tailwind/react as a dependency using Bun by running the following command:
+
+<span id="Bun" className="scroll-mt-48" />
+
+```bash
+bun add @material-tailwind/react
 ```
 
 ---
@@ -167,7 +174,7 @@ module.exports = withMT({
 
 @material-tailwind/react comes with a theme provider that sets the default or custom theme/styles for Material Tailwind components. Wrap your entire application with the <Code>ThemeProvider</Code> component from @material-tailwind/react. The file to add this to depends on your Next.js setup:
 
-With the App Router: <Code>app/layout</Code>  
+With the App Router: <Code>app/layout</Code>
 With the Pages Router: <Code>pages/\_app</Code>
 
 ```jsx {3, 7, 9}

--- a/documentation/react/guide/remix.mdx
+++ b/documentation/react/guide/remix.mdx
@@ -4,9 +4,10 @@ description: Learn how to use Material Tailwind components with Remix and Tailwi
 navigation:
   [
     "installation",
-    "npm",
-    "yarn",
-    "pnpm",
+    "NPM",
+    "Yarn",
+    "PNPM",
+    "Bun",
     "tailwindcss-config",
     "with-monorepo",
     "theme-provider",
@@ -38,13 +39,11 @@ Check <a href="https://tailwindcss.com/docs/guides/remix?ref=material-tailwind" 
 
 ---
 
-<DocsTitle href="npm">
 ## Using NPM
-</DocsTitle>
 
 Install @material-tailwind/react as a dependency using NPM by running the following command:
 
-<span id="npm" className="scroll-mt-48" />
+<span id="NPM" className="scroll-mt-48" />
 
 ```bash
 npm i @material-tailwind/react
@@ -52,13 +51,11 @@ npm i @material-tailwind/react
 
 ---
 
-<DocsTitle href="yarn">
 ## Using Yarn
-</DocsTitle>
 
 Install @material-tailwind/react as a dependency using Yarn by running the following command:
 
-<span id="yarn" className="scroll-mt-48" />
+<span id="Yarn" className="scroll-mt-48" />
 
 ```bash
 yarn add @material-tailwind/react
@@ -66,16 +63,26 @@ yarn add @material-tailwind/react
 
 ---
 
-<DocsTitle href="pnpm">
 ## Using PNPM
-</DocsTitle>
 
 Install @material-tailwind/react as a dependency using PNPM by running the following command:
 
-<span id="pnpm" className="scroll-mt-48" />
+<span id="PNPM" className="scroll-mt-48" />
 
 ```bash
 pnpm i @material-tailwind/react
+```
+
+---
+
+## Using Bun
+
+Install @material-tailwind/react as a dependency using Bun by running the following command:
+
+<span id="Bun" className="scroll-mt-48" />
+
+```bash
+bun add @material-tailwind/react
 ```
 
 ---

--- a/documentation/react/guide/vite.mdx
+++ b/documentation/react/guide/vite.mdx
@@ -4,9 +4,10 @@ description: Learn how to use Material Tailwind components with Vite (React) and
 navigation:
   [
     "installation",
-    "npm",
-    "yarn",
-    "pnpm",
+    "NPM",
+    "Yarn",
+    "PNPM",
+    "Bun",
     "tailwindcss-config",
     "with-monorepo",
     "theme-provider",
@@ -38,13 +39,11 @@ Check <a href="https://tailwindcss.com/docs/guides/vite?ref=material-tailwind" t
 
 ---
 
-<DocsTitle href="npm">
 ## Using NPM
-</DocsTitle>
 
 Install @material-tailwind/react as a dependency using NPM by running the following command:
 
-<span id="npm" className="scroll-mt-48" />
+<span id="NPM" className="scroll-mt-48" />
 
 ```bash
 npm i @material-tailwind/react
@@ -52,13 +51,11 @@ npm i @material-tailwind/react
 
 ---
 
-<DocsTitle href="yarn">
 ## Using Yarn
-</DocsTitle>
 
 Install @material-tailwind/react as a dependency using Yarn by running the following command:
 
-<span id="yarn" className="scroll-mt-48" />
+<span id="Yarn" className="scroll-mt-48" />
 
 ```bash
 yarn add @material-tailwind/react
@@ -70,10 +67,22 @@ yarn add @material-tailwind/react
 
 Install @material-tailwind/react as a dependency using PNPM by running the following command:
 
-<span id="pnpm" className="scroll-mt-48" />
+<span id="PNPM" className="scroll-mt-48" />
 
 ```bash
 pnpm i @material-tailwind/react
+```
+
+---
+
+## Using Bun
+
+Install @material-tailwind/react as a dependency using Bun by running the following command:
+
+<span id="Bun" className="scroll-mt-48" />
+
+```bash
+bun add @material-tailwind/react
 ```
 
 ---

--- a/documentation/react/installation-with-cli.mdx
+++ b/documentation/react/installation-with-cli.mdx
@@ -31,6 +31,9 @@ yarn create material-tailwind
 
 # Using PNPM
 pnpm create material-tailwind
+
+# Using Bun
+bun create material-tailwind
 ```
 
 <br />

--- a/documentation/react/installation.mdx
+++ b/documentation/react/installation.mdx
@@ -5,6 +5,10 @@ navigation:
   [
     "quick-start",
     "installation",
+    "NPM",
+    "Yarn",
+    "PNPM",
+    "Bun",
     "frameworks-integration",
     "typescript",
   ]
@@ -38,7 +42,7 @@ Learn how to use @material-tailwind/react components from this documentation to 
 
 Install @material-tailwind/react as a dependency using NPM by running the following command:
 
-<span id="npm" className="scroll-mt-48" />
+<span id="NPM" className="scroll-mt-48" />
 
 ```bash
 npm i @material-tailwind/react
@@ -50,7 +54,7 @@ npm i @material-tailwind/react
 
 Install @material-tailwind/react as a dependency using Yarn by running the following command:
 
-<span id="yarn" className="scroll-mt-48" />
+<span id="Yarn" className="scroll-mt-48" />
 
 ```bash
 yarn add @material-tailwind/react
@@ -62,10 +66,22 @@ yarn add @material-tailwind/react
 
 Install @material-tailwind/react as a dependency using PNPM by running the following command:
 
-<span id="pnpm" className="scroll-mt-48" />
+<span id="PNPM" className="scroll-mt-48" />
 
 ```bash
 pnpm i @material-tailwind/react
+```
+
+---
+
+## Using Bun
+
+Install @material-tailwind/react as a dependency using Bun by running the following command:
+
+<span id="Bun" className="scroll-mt-48" />
+
+```bash
+bun add @material-tailwind/react
 ```
 
 ---

--- a/packages/create-material-tailwind/.gitignore
+++ b/packages/create-material-tailwind/.gitignore
@@ -3,3 +3,5 @@ node_modules
 package-lock.json
 yarn.lock
 pnpm-lock.yaml
+bun.lockb
+bun.lock

--- a/packages/create-material-tailwind/README.md
+++ b/packages/create-material-tailwind/README.md
@@ -23,6 +23,12 @@ With PNPM:
 $ pnpm create material-tailwind
 ```
 
+With Bun:
+
+```bash
+$ bun create material-tailwind
+```
+
 Then follow the prompts!
 
 You can also directly specify the project name and the template you want to use via additional command line options. For example, to scaffold a Material Tailwind project for Next.js, run:

--- a/packages/create-material-tailwind/templates/next-ts/README.md
+++ b/packages/create-material-tailwind/templates/next-ts/README.md
@@ -10,6 +10,8 @@ npm run dev
 yarn dev
 # or
 pnpm dev
+# or
+bun run dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.

--- a/packages/create-material-tailwind/templates/next/README.md
+++ b/packages/create-material-tailwind/templates/next/README.md
@@ -10,6 +10,8 @@ npm run dev
 yarn dev
 # or
 pnpm dev
+# or
+bun run dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.

--- a/packages/material-tailwind-html/.gitignore
+++ b/packages/material-tailwind-html/.gitignore
@@ -26,3 +26,6 @@ dist-ssr
 # lock files
 package-lock.json
 yarn.lock
+pnpm-lock.yaml
+bun.lockb
+bun.lock

--- a/packages/material-tailwind-react/.gitignore
+++ b/packages/material-tailwind-react/.gitignore
@@ -26,3 +26,6 @@ dist-ssr
 # lock files
 package-lock.json
 yarn.lock
+pnpm-lock.yaml
+bun.lockb
+bun.lock


### PR DESCRIPTION
## Summary

This PR changes the entire project documentation CLI examples to use [Bun](https://bun.sh/) as an alternative of package manager.

This also takes the chance to increase code consistency across documenation